### PR TITLE
Update README.md to use correct dependency name

### DIFF
--- a/packages/frame-wagmi-connector/README.md
+++ b/packages/frame-wagmi-connector/README.md
@@ -9,5 +9,5 @@ Not yet stable. [Learn more](https://github.com/farcasterxyz/frames/wiki/frames-
 Install using your favorite manager:
 
 ```
-npm install @farcaster/frame-connector
+npm install @farcaster/frame-wagmi-connector
 ```


### PR DESCRIPTION
got a 404 in the install and realised the name on npm was different to readme