### PR TITLE
Performance improvement: import ox modules directly

### DIFF
--- a/packages/frame-core/src/wallet/ethereum.ts
+++ b/packages/frame-core/src/wallet/ethereum.ts
@@ -1,4 +1,8 @@
-import type { Address, Provider, RpcRequest, RpcResponse, RpcSchema } from 'ox'
+import type * as Address from 'ox/Address'
+import type * as Provider from 'ox/Provider'
+import type * as RpcRequest from 'ox/RpcRequest'
+import type * as RpcResponse from 'ox/RpcResponse'
+import type * as RpcSchema from 'ox/RpcSchema'
 
 export type EthProvideRequest<
   schema extends RpcSchema.Generic = RpcSchema.Default,

--- a/packages/frame-host-react-native/src/webviewAdapter.ts
+++ b/packages/frame-host-react-native/src/webviewAdapter.ts
@@ -1,12 +1,11 @@
 import type { FrameHost } from '@farcaster/frame-host'
 import { exposeToEndpoint, useExposeToEndpoint } from '@farcaster/frame-host'
-import type { Provider } from 'ox'
+import type { Provider } from 'ox/Provider'
 import {
   type RefObject,
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import type WebView from 'react-native-webview'
@@ -24,7 +23,7 @@ export function useWebViewRpcAdapter({
 }: {
   webViewRef: RefObject<WebView>
   sdk: Omit<FrameHost, 'ethProviderRequestV2'>
-  ethProvider?: Provider.Provider
+  ethProvider?: Provider
   debug?: boolean
 }) {
   const [endpoint, setEndpoint] = useState<WebViewEndpoint>()
@@ -100,7 +99,7 @@ export function useExposeWebViewToEndpoint({
 }: {
   endpoint: WebViewEndpoint | undefined
   sdk: Omit<FrameHost, 'ethProviderRequestV2'>
-  ethProvider?: Provider.Provider
+  ethProvider?: Provider
   debug?: boolean
 }) {
   useExposeToEndpoint({

--- a/packages/frame-host/src/helpers/endpoint.ts
+++ b/packages/frame-host/src/helpers/endpoint.ts
@@ -1,5 +1,5 @@
 import type { FrameHost } from '@farcaster/frame-core'
-import type { Provider } from 'ox'
+import type * as Provider from 'ox/Provider'
 import { useEffect } from 'react'
 import * as Comlink from '../comlink'
 import type { HostEndpoint } from '../types'

--- a/packages/frame-host/src/helpers/provider.ts
+++ b/packages/frame-host/src/helpers/provider.ts
@@ -1,4 +1,6 @@
-import { Provider, type RpcRequest, RpcResponse } from 'ox'
+import * as Provider from 'ox/Provider'
+import type * as RpcRequest from 'ox/RpcRequest'
+import * as RpcResponse from 'ox/RpcResponse'
 import type { HostEndpoint } from '../types'
 
 export function forwardProviderEvents({

--- a/packages/frame-host/src/iframe.ts
+++ b/packages/frame-host/src/iframe.ts
@@ -1,5 +1,5 @@
 import type { FrameHost } from '@farcaster/frame-core'
-import type { Provider } from 'ox'
+import type { Provider } from 'ox/Provider'
 import * as Comlink from './comlink'
 import { exposeToEndpoint } from './helpers/endpoint'
 import type { HostEndpoint } from './types'
@@ -57,7 +57,7 @@ export function exposeToIframe({
   iframe: HTMLIFrameElement
   sdk: Omit<FrameHost, 'ethProviderRequestV2'>
   frameOrigin: string
-  ethProvider?: Provider.Provider
+  ethProvider?: Provider
   debug?: boolean
 }) {
   const endpoint = createIframeEndpoint({

--- a/packages/frame-node/src/farcaster.ts
+++ b/packages/frame-node/src/farcaster.ts
@@ -1,4 +1,4 @@
-import { AbiParameters } from 'ox'
+import * as AbiParameters from 'ox/AbiParameters'
 import { z } from 'zod'
 import { BaseError, type VerifyAppKey, type VerifyAppKeyResult } from './types'
 

--- a/packages/frame-sdk/src/provider.ts
+++ b/packages/frame-sdk/src/provider.ts
@@ -8,7 +8,9 @@ import type {
   EIP1193Provider,
   EIP6963ProviderDetail,
 } from 'mipd'
-import { Provider, RpcRequest, RpcResponse } from 'ox'
+import * as Provider from 'ox/Provider'
+import * as RpcRequest from 'ox/RpcRequest'
+import * as RpcResponse from 'ox/RpcResponse'
 import { frameHost } from './frameHost'
 
 const emitter = Provider.createEmitter()

--- a/packages/frame-sdk/src/types.ts
+++ b/packages/frame-sdk/src/types.ts
@@ -11,7 +11,7 @@ import type {
   ViewToken,
 } from '@farcaster/frame-core'
 import type { EventEmitter } from 'eventemitter3'
-import type { Provider } from 'ox'
+import type * as Provider from 'ox/Provider'
 
 declare global {
   interface Window {


### PR DESCRIPTION
This PR addresses a performance issue for imports from `ox`.  Using certain exports in this package is slow because default ox exports are slow.

- The index file in Ox [exports a file called BlsPoint](https://github.com/wevm/ox/blob/c374ecb70d66f2e112b4d83282f7b48788c772ad/src/index.ts#L1169)
- BlsPoint [imports bls12-381 from noble/curves](https://github.com/wevm/ox/blob/c374ecb70d66f2e112b4d83282f7b48788c772ad/src/core/BlsPoint.ts#L1)
- bls12-381 [calls tower12 when defining some consts](https://github.com/paulmillr/noble-curves/blob/e9eef8b76434ba9bc24f71189b05433d7c685a02/src/bls12-381.ts#L95)
- => tower12 is slow

Here is a screenshot of a profile showing that importing `useWebviewRpcAdapter` is taking 2s because that file currently imports `Provider` directly from `ox`:

<img width="898" alt="Screenshot 2025-04-15 at 3 20 42 PM" src="https://github.com/user-attachments/assets/d2a40db3-e201-40a5-9102-1a5ba9164c1e" />


Importing directly from the required module in `ox` fixes this issue.
