### PR TITLE
feat: add isInMiniApp helper to detect MiniApp environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ npm-debug.log*
 # Misc
 .DS_Store
 *.pem
+
+**/.claude/settings.local.json

--- a/packages/frame-sdk/src/sdk.ts
+++ b/packages/frame-sdk/src/sdk.ts
@@ -31,11 +31,11 @@ const emitter = createEmitter()
 
 /**
  * Determines if the current environment is a MiniApp context.
- * 
+ *
  * @param timeoutMs - Optional timeout in milliseconds (default: 100)
  * @returns Promise resolving to boolean indicating if in MiniApp context
  */
-async function isInMiniApp(timeoutMs: number = 100): Promise<boolean> {
+async function isInMiniApp(timeoutMs = 100): Promise<boolean> {
   // Check for SSR environment
   if (typeof window === 'undefined') {
     return false
@@ -53,10 +53,10 @@ async function isInMiniApp(timeoutMs: number = 100): Promise<boolean> {
 
   // If synchronous checks don't confirm, try async approach with timeout
   return Promise.race([
-    frameHost.context.then(context => !!context),
-    new Promise<boolean>(resolve => {
+    frameHost.context.then((context) => !!context),
+    new Promise<boolean>((resolve) => {
       setTimeout(() => resolve(false), timeoutMs)
-    })
+    }),
   ])
 }
 

--- a/packages/frame-sdk/src/sdk.ts
+++ b/packages/frame-sdk/src/sdk.ts
@@ -36,7 +36,7 @@ let cachedIsInMiniAppResult: boolean | null = null
  * @param timeoutMs - Optional timeout in milliseconds (default: 100)
  * @returns Promise resolving to boolean indicating if in MiniApp context
  */
-async function isInMiniApp(timeoutMs = 100): Promise<boolean> {
+async function isInMiniApp(timeoutMs = 150): Promise<boolean> {
   // Return cached result if we've already determined we are in a MiniApp
   if (cachedIsInMiniAppResult === true) {
     return true

--- a/packages/frame-sdk/src/types.ts
+++ b/packages/frame-sdk/src/types.ts
@@ -51,6 +51,7 @@ export type Emitter = Compute<EventEmitter<EventMap>>
 type SetPrimaryButton = (options: SetPrimaryButtonOptions) => Promise<void>
 
 export type FrameSDK = {
+  isInMiniApp: () => Promise<boolean>
   context: Promise<Context.FrameContext>
   actions: {
     ready: (options?: Partial<Ready.ReadyOptions>) => Promise<void>

--- a/site/pages/docs/sdk/changelog.mdx
+++ b/site/pages/docs/sdk/changelog.mdx
@@ -5,6 +5,10 @@ description: Recent changes to the Mini Apps SDK
 
 # What's New
 
+## May 2, 2025 (0.0.38)
+
+- Added [`isInMiniApp`](/docs/sdk/is-in-mini-app) function to reliably detect Mini App environments
+
 ## April 30, 2025 (0.0.37)
 
 - Added experimental actions for [`swapToken`](/docs/sdk/actions/swap-token), [`sendToken`](/docs/sdk/actions/send-token), and [`viewToken`](/docs/sdk/actions/view-token)

--- a/site/pages/docs/sdk/is-in-mini-app.mdx
+++ b/site/pages/docs/sdk/is-in-mini-app.mdx
@@ -1,0 +1,52 @@
+---
+title: isInMiniApp
+description: Detect if your app is running in a Mini App environment
+---
+
+# isInMiniApp
+
+Determines if the current environment is a Mini App context by analyzing both environment characteristics and communication capabilities.
+
+## Usage
+
+```ts twoslash
+import { sdk } from '@farcaster/frame-sdk'
+
+// Check if running in a Mini App
+const isMiniApp = await sdk.isInMiniApp()
+
+if (isMiniApp) {
+  // Mini App-specific code
+} else {
+  // Regular web app code
+}
+```
+
+## Parameters
+
+### timeoutMs (optional)
+
+- **Type:** `number`
+- **Default:** `100`
+
+Optional timeout in milliseconds for context verification. If the context doesn't resolve within this time, the function assumes it's not in a Mini App environment.
+
+## Return Value
+
+- **Type:** `Promise<boolean>`
+
+Returns a promise that resolves to `true` if running in a Mini App context, or `false` otherwise.
+
+## Details
+
+The function uses a multi-step approach to detect Mini App environments:
+
+1. **Fast Short-Circuit:** Returns `false` immediately in certain scenarios:
+   - During server-side rendering
+   - When neither in an iframe nor in ReactNative WebView
+
+2. **Context Verification:** For potential Mini App environments (iframe or ReactNative WebView), verifies by checking for context communication.
+
+3. **Result Caching:** Once confirmed to be in a Mini App, the result is cached for faster subsequent calls.
+
+This approach ensures accurate detection while optimizing performance.


### PR DESCRIPTION
Some developers at the Bulders day have been advising me to add more explicit boolean function that detects if you are in a mini app or not. I've also noticed this same experience and issue when building Bountycaster's mini app, since we have many shared components that need to behave differently according to the context they are in.

Solution: added a `isInMiniApp` function that returns `true` if the context is running inside a mini app