### PR TITLE
fix: rename `snake_cast` to `snake_case`

### DIFF
--- a/packages/frame-core/CHANGELOG.md
+++ b/packages/frame-core/CHANGELOG.md
@@ -163,7 +163,7 @@
 
 - 06ca566: optional ready options
 - 7f35aa5: Switch notificationId to a string from a UUID
-- aaf9e0e: Standardize literals to snake_cast and add cast_embed location context + client context
+- aaf9e0e: Standardize literals to snake_case and add cast_embed location context + client context
 
 ## 0.0.10
 


### PR DESCRIPTION
Corrects typo: replaces `snake_cast` with `snake_case` across schemas and docs. No functional changes.






