### PR TITLE
Clarify how to access Mini App Debug Tool 

### DIFF
--- a/site/pages/docs/guides/loading.mdx
+++ b/site/pages/docs/guides/loading.mdx
@@ -22,7 +22,7 @@ is ready to show the splash screen can be hidden.
 
 Call [ready](/docs/sdk/actions/ready) when your interface is ready to be displayed:
 
-```ts twoslash
+```ts
 import { sdk } from '@farcaster/frame-sdk'
 
 await sdk.actions.ready();
@@ -72,3 +72,7 @@ Let's preview it in Warpcast:
 on desktop
 2. Enter your app url
 3. Hit _Preview_
+
+:::info
+You must be logged into your Warpcast account on desktop to access the Mini App Debug Tool.
+:::

--- a/site/pages/docs/guides/loading.mdx
+++ b/site/pages/docs/guides/loading.mdx
@@ -22,7 +22,7 @@ is ready to show the splash screen can be hidden.
 
 Call [ready](/docs/sdk/actions/ready) when your interface is ready to be displayed:
 
-```ts
+```ts twoslash
 import { sdk } from '@farcaster/frame-sdk'
 
 await sdk.actions.ready();


### PR DESCRIPTION
I added a clarifying callout on how to access the miniapp debug tool. It's probably obvious to devs, but it held me up for like 5 minutes because it was redirecting back to the home page, so I was assuming the page didn't exist anymore. Anyways, it can probably save someone else some time.