### PR TITLE
[pages] Fix docs to reflect moved token APIs

### DIFF
--- a/site/pages/docs/sdk/actions/send-token.mdx
+++ b/site/pages/docs/sdk/actions/send-token.mdx
@@ -18,7 +18,7 @@ const recipientFid = 3;
 // ---cut---
 import { sdk } from '@farcaster/frame-sdk'
 
-await sdk.experimental.sendToken({ 
+await sdk.actions.sendToken({ 
   token,
   amount,
   recipientFid,

--- a/site/pages/docs/sdk/actions/swap-token.mdx
+++ b/site/pages/docs/sdk/actions/swap-token.mdx
@@ -18,7 +18,7 @@ const sellAmount = "1000000";
 // ---cut---
 import { sdk } from '@farcaster/frame-sdk'
 
-await sdk.experimental.swapToken({ 
+await sdk.actions.swapToken({ 
   sellToken,
   buyToken,
   sellAmount,

--- a/site/pages/docs/sdk/actions/view-token.mdx
+++ b/site/pages/docs/sdk/actions/view-token.mdx
@@ -15,7 +15,7 @@ const token = "eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 // ---cut---
 import { sdk } from '@farcaster/frame-sdk'
 
-await sdk.experimental.viewToken({ 
+await sdk.actions.viewToken({ 
   token
 })
 ```


### PR DESCRIPTION
These were moved from `experimental` to `actions`, but I missed updated the docs. I discovered this because `pnpm build` was failing locally in `pages`... not sure why CI didn't flag.