### PR TITLE
Add Mini App detection docs to vocs config

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -39,11 +39,6 @@
       "source": "/docs/actions/view-profile",
       "destination": "/docs/sdk/actions/view-profile",
       "statusCode": 301
-    },
-    {
-      "source": "/docs/is-in-mini-app",
-      "destination": "/docs/sdk/is-in-mini-app",
-      "statusCode": 301
     }
   ]
 }

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -39,6 +39,11 @@
       "source": "/docs/actions/view-profile",
       "destination": "/docs/sdk/actions/view-profile",
       "statusCode": 301
+    },
+    {
+      "source": "/docs/is-in-mini-app",
+      "destination": "/docs/sdk/is-in-mini-app",
+      "statusCode": 301
     }
   ]
 }

--- a/site/vocs.config.tsx
+++ b/site/vocs.config.tsx
@@ -115,7 +115,7 @@ export default defineConfig({
           },
           {
             text: 'Mini App Detection',
-            link: 'docs/sdk/is-in-mini-app',
+            link: '/docs/sdk/is-in-mini-app',
           },
           {
             text: 'Actions',

--- a/site/vocs.config.tsx
+++ b/site/vocs.config.tsx
@@ -114,6 +114,10 @@ export default defineConfig({
             link: '/docs/sdk/context',
           },
           {
+            text: 'Mini App Detection',
+            link: 'docs/sdk/is-in-mini-app',
+          },
+          {
             text: 'Actions',
             collapsed: true,
             items: [

--- a/site/vocs.config.tsx
+++ b/site/vocs.config.tsx
@@ -114,7 +114,7 @@ export default defineConfig({
             link: '/docs/sdk/context',
           },
           {
-            text: 'Mini App Detection',
+            text: 'Mini app detection',
             link: '/docs/sdk/is-in-mini-app',
           },
           {


### PR DESCRIPTION
Currently the new `isInMiniApp` SDK function is not in the vocs config. Making it invisible for the users.

Make the new is-in miniapp sdk function docs page avaliable in the site side panel. :D 

![Screenshot 2025-05-14 at 9 02 01 p m](https://github.com/user-attachments/assets/c171ecae-92b7-4d91-bce7-d75ef6ff8adb)
