### PR TITLE
Fix signTransaction decoding from base58 to base64

### DIFF
--- a/.changeset/large-lines-learn.md
+++ b/.changeset/large-lines-learn.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/mini-app-solana": patch
+---
+
+Fix signTransaction decoding from base58 to base64

--- a/packages/mini-app-solana/src/wallet.ts
+++ b/packages/mini-app-solana/src/wallet.ts
@@ -200,7 +200,7 @@ export class FarcasterSolanaWallet implements Wallet {
       method: 'signTransaction',
       params: { transaction: transactionStr },
     })
-    const signatureBytes = base58.decode(signedTransaction)
+    const signatureBytes = Buffer.from(signedTransaction, 'base64')
     return { signedTransaction: signatureBytes }
   }
 


### PR DESCRIPTION
Privy returns as base58 transaction hash for `signAndSendTransaction`, but a base64 one for `signTransaction`.