### PR TITLE
Fix package installation command in README

### DIFF
--- a/packages/frame-core/README.md
+++ b/packages/frame-core/README.md
@@ -5,7 +5,7 @@ Build onchain social apps
 ## Installation
 
 ```bash
-pnpm add @farcaster/core
+pnpm add @farcaster/frame-core
 ```
 
 ## Documentation


### PR DESCRIPTION
Corrected the package name in the installation command from `@farcaster/core` to `@farcaster/frame-core` to match the actual package name