### PR TITLE
 Standardize string literals from snake_cast to snake_case

### DIFF
--- a/packages/frame-core/CHANGELOG.md
+++ b/packages/frame-core/CHANGELOG.md
@@ -215,7 +215,7 @@
 
 - 06ca566: optional ready options
 - 7f35aa5: Switch notificationId to a string from a UUID
-- aaf9e0e: Standardize literals to snake_cast and add cast_embed location context + client context
+- aaf9e0e: Standardize literals to snake_case and add cast_embed location context + client context
 
 ## 0.0.10
 


### PR DESCRIPTION
Corrected the formatting of string literals to use consistent snake_case naming convention across the codebase.