### PR TITLE
Fix capability in example: evm->ethereum

### DIFF
--- a/site/pages/docs/guides/publishing.mdx
+++ b/site/pages/docs/guides/publishing.mdx
@@ -79,7 +79,7 @@ Here's an example `farcaster.json` file:
     ],
     "requiredCapabilities": [
       "actions.signIn",
-      "wallet.getEvmProvider",
+      "wallet.getEthereumProvider",
       "actions.swapToken"
     ]
   }


### PR DESCRIPTION
I copy-pasted the example .well-known/farcaster.json and debugged some error leading me to realise the "getEvmProvider" should be "getEthereumProvider" as per https://github.com/farcasterxyz/miniapps/blob/main/packages/frame-core/src/types.ts#L37