### PR TITLE
Improve farcaster manifest schema validation and type

### DIFF
--- a/packages/frame-core/src/schemas/manifest.ts
+++ b/packages/frame-core/src/schemas/manifest.ts
@@ -25,7 +25,7 @@ const primaryCategorySchema = z.enum([
   'art-creativity',
 ])
 
-const chainList: [string, ...string[]] = [
+const chainList = [
   'eip155:1', // Ethereum mainnet
   'eip155:8453', // Base mainnet
   'eip155:42161', // Arbitrum One
@@ -42,7 +42,12 @@ const chainList: [string, ...string[]] = [
   'eip155:10143', // Monad testnet
   'eip155:42220', // Celo
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', // Solana
-]
+] as const satisfies [string, ...string[]]
+
+function removeArrayDuplicates<T>(arr: T[]) {
+  const set = new Set(arr)
+  return Array.from(set)
+}
 
 export const domainFrameConfigSchema = z
   .object({
@@ -82,10 +87,13 @@ export const domainFrameConfigSchema = z
     /** see: https://github.com/farcasterxyz/miniapps/discussions/204 */
     noindex: z.boolean().optional(),
     /** see https://github.com/farcasterxyz/miniapps/discussions/256 */
-    requiredChains: z.array(z.enum(chainList)).max(chainList.length).optional(),
+    requiredChains: z
+      .array(z.enum(chainList))
+      .transform(removeArrayDuplicates)
+      .optional(),
     requiredCapabilities: z
       .array(z.enum(miniAppHostCapabilityList))
-      .max(miniAppHostCapabilityList.length)
+      .transform(removeArrayDuplicates)
       .optional(),
     /** see https://github.com/farcasterxyz/miniapps/discussions/158 */
     /** Documentation will be added once this feature is finalized. */

--- a/packages/frame-core/src/types.ts
+++ b/packages/frame-core/src/types.ts
@@ -43,7 +43,7 @@ export type SetPrimaryButton = (options: SetPrimaryButtonOptions) => void
 // Export haptics types
 export type { ImpactOccurred, NotificationOccurred, SelectionChanged }
 
-export const miniAppHostCapabilityList: [string, ...string[]] = [
+export const miniAppHostCapabilityList = [
   'wallet.getEthereumProvider',
   'wallet.getSolanaProvider',
   'actions.ready',
@@ -62,27 +62,9 @@ export const miniAppHostCapabilityList: [string, ...string[]] = [
   'haptics.notificationOccurred',
   'haptics.selectionChanged',
   'back',
-]
+] as const satisfies [string, ...string[]]
 
-export type MiniAppHostCapability =
-  | 'wallet.getEthereumProvider'
-  | 'wallet.getSolanaProvider'
-  | 'actions.ready'
-  | 'actions.openUrl'
-  | 'actions.close'
-  | 'actions.setPrimaryButton'
-  | 'actions.addMiniApp'
-  | 'actions.signIn'
-  | 'actions.viewCast'
-  | 'actions.viewProfile'
-  | 'actions.composeCast'
-  | 'actions.viewToken'
-  | 'actions.sendToken'
-  | 'actions.swapToken'
-  | 'haptics.impactOccurred'
-  | 'haptics.notificationOccurred'
-  | 'haptics.selectionChanged'
-  | 'back'
+export type MiniAppHostCapability = (typeof miniAppHostCapabilityList)[number]
 
 export type GetCapabilities = () => Promise<MiniAppHostCapability[]>
 


### PR DESCRIPTION
Updated `requiredChains` and `requiredCapabilities` in the `domainFrameConfigSchema` zod schema to make it so that 

```ts
type Manifest = z.input<typeof domainManifestSchema>;
```

Would yield a type that autocompletes all available options in the enum for both manifest settings. Also added a function to transform the input into a set, replacing the `max()` validation. I assumed this was added in an attempt to prevent duplicates. Using a set to remove duplicates seems like a better solution.


<img width="471" alt="Screenshot 2025-06-07 at 12 05 11 PM" src="https://github.com/user-attachments/assets/faab947b-b189-4e49-ac88-c64eed740cfc" />

