### PR TITLE
chore: update repository URLs from 'frames' to 'miniapps'

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "baseBranch": "main",
   "changelog": [
     "@changesets/changelog-github",
-    { "repo": "farcasterxyz/frames" }
+    { "repo": "farcasterxyz/miniapps"}
   ],
   "commit": false,
   "fixed": [],

--- a/.github/README.md
+++ b/.github/README.md
@@ -20,7 +20,7 @@
       <img src="https://img.shields.io/npm/v/@farcaster/frame-sdk?colorA=f6f8fa&colorB=f6f8fa" alt="Version">
     </picture>
   </a>
-  <a href="https://github.com/farcasterxyz/frames/blob/main/LICENSE">
+  <a href="https://github.com/farcasterxyz/miniapps/blob/main/LICENSE">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/npm/l/@farcaster/frame-sdk?colorA=21262d&colorB=21262d">
       <img src="https://img.shields.io/npm/l/@farcaster/frame-sdk?colorA=f6f8fa&colorB=f6f8fa" alt="MIT License">

--- a/packages/frame-core/package.json
+++ b/packages/frame-core/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/farcasterxyz/frames.git",
+    "url": "https://github.com/farcasterxyz/miniapps.git",
     "directory": "packages/frame-core"
   },
   "main": "dist/index.js",

--- a/packages/frame-host-react-native/package.json
+++ b/packages/frame-host-react-native/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/farcasterxyz/frames.git",
+    "url": "https://github.com/farcasterxyz/miniapps.git",
     "directory": "packages/frame-host-react-native"
   },
   "main": "dist/index.js",

--- a/packages/frame-host/package.json
+++ b/packages/frame-host/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/farcasterxyz/frames.git",
+    "url": "https://github.com/farcasterxyz/miniapps.git",
     "directory": "packages/frame-host"
   },
   "main": "dist/index.js",

--- a/packages/frame-node/package.json
+++ b/packages/frame-node/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/farcasterxyz/frames.git",
+    "url": "https://github.com/farcasterxyz/miniapps.git",
     "directory": "packages/frame-node"
   },
   "main": "dist/index.js",

--- a/packages/frame-sdk/package.json
+++ b/packages/frame-sdk/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/farcasterxyz/frames.git",
+    "url": "https://github.com/farcasterxyz/miniapps.git",
     "directory": "packages/frame-sdk"
   },
   "main": "dist/index.js",

--- a/packages/frame-wagmi-connector/package.json
+++ b/packages/frame-wagmi-connector/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/farcasterxyz/frames.git",
+    "url": "https://github.com/farcasterxyz/miniapps.git",
     "directory": "packages/frame-wagmi-connector"
   },
   "type": "module",

--- a/site/pages/docs/getting-started.mdx
+++ b/site/pages/docs/getting-started.mdx
@@ -18,7 +18,7 @@ with the user's wallet.
 ## Quick Start
 
 For new projects, you can set up an app using the
-[@farcaster/create-mini-app](https://github.com/farcasterxyz/frames/tree/main/packages/create-mini-app)
+[@farcaster/create-mini-app](https://github.com/farcasterxyz/miniapps/tree/main/packages/create-mini-app)
 CLI. This will prompt you to set up a project for your app.
 
 :::code-group

--- a/site/pages/docs/guides/notifications.mdx
+++ b/site/pages/docs/guides/notifications.mdx
@@ -284,7 +284,7 @@ Mini Apps to verify the Farcaster client that generated the notification and the
 Farcaster user they generated it for. 
 
 The
-[`@farcaster/frame-node`](https://github.com/farcasterxyz/frames/tree/main/packages/frame-node)
+[`@farcaster/frame-node`](https://github.com/farcasterxyz/miniapps/tree/main/packages/frame-node)
 library provides a helper for verifying events. To use it, you'll need to supply a validation
 function that can check the signatures against the latest Farcaster network state.
 

--- a/site/vocs.config.tsx
+++ b/site/vocs.config.tsx
@@ -13,7 +13,7 @@ export default defineConfig({
   titleTemplate: '%s · Farcaster Mini Apps',
   editLink: {
     pattern:
-      'https://github.com/farcasterxyz/frames/edit/main/site/pages/:path',
+      'https://github.com/farcasterxyz/miniapps/edit/main/site/pages/:path',
     text: 'Edit on GitHub',
   },
   iconUrl: '/favicon.png',
@@ -58,7 +58,7 @@ export default defineConfig({
     },
     {
       text: 'Examples',
-      link: 'https://github.com/farcasterxyz/frames/tree/main/examples',
+      link: 'https://github.com/farcasterxyz/miniapps/tree/main/examples',
     },
     { text: 'Rewards', link: 'https://farcaster.xyz/~/developers/rewards' },
   ],
@@ -247,7 +247,7 @@ export default defineConfig({
   socials: [
     {
       icon: 'github',
-      link: 'https://github.com/farcasterxyz/frames',
+      link: 'https://github.com/farcasterxyz/miniapps',
     },
     {
       icon: 'x',


### PR DESCRIPTION
I noticed that the npmjs registry still points to the old repo url.

This PR updates the references to the previous repo name to the current name.

![image](https://github.com/user-attachments/assets/36a80107-7d69-4104-b502-373ce0906ca3)
