### PR TITLE
accept 1 for mini app embed schema

### DIFF
--- a/.changeset/happy-bottles-sell.md
+++ b/.changeset/happy-bottles-sell.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/frame-core": patch
+---
+
+Accept version '1' for current Embed schema.

--- a/packages/frame-core/src/schemas/embeds.ts
+++ b/packages/frame-core/src/schemas/embeds.ts
@@ -32,7 +32,7 @@ export const buttonSchema = z.object({
 })
 
 export const frameEmbedNextSchema = z.object({
-  version: z.literal('next'),
+  version: z.union([z.literal('next'), z.literal('1')]),
   imageUrl: secureUrlSchema,
   aspectRatio: aspectRatioSchema.optional(),
   button: buttonSchema,

--- a/packages/frame-core/tests/schemas/embeds.test.ts
+++ b/packages/frame-core/tests/schemas/embeds.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import {
   actionLaunchFrameSchema,
   actionSchema,
+  frameEmbedNextSchema,
 } from '../../src/schemas/embeds.ts'
 
 describe('actionLaunchFrameSchema', () => {
@@ -75,5 +76,65 @@ describe('actionViewTokenSchema', () => {
       })
       expect(result.success, `Expected invalid CAIP-19: ${id}`).toBe(false)
     }
+  })
+})
+
+describe('frameEmbedNextSchema', () => {
+  const baseEmbed = {
+    imageUrl: 'https://example.com/image.png',
+    button: {
+      title: 'Click me',
+      action: {
+        type: 'launch_frame' as const,
+        name: 'Test',
+        url: 'https://example.com/frame',
+      },
+    },
+  }
+
+  test('valid with version "next"', () => {
+    const result = frameEmbedNextSchema.safeParse({
+      ...baseEmbed,
+      version: 'next',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('valid with version "1"', () => {
+    const result = frameEmbedNextSchema.safeParse({
+      ...baseEmbed,
+      version: '1',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('invalid with other version values', () => {
+    const invalidVersions = ['0', '2', '0.0.1', 'v1', 'latest']
+
+    for (const version of invalidVersions) {
+      const result = frameEmbedNextSchema.safeParse({
+        ...baseEmbed,
+        version,
+      })
+      expect(result.success, `Expected invalid version: ${version}`).toBe(false)
+    }
+  })
+
+  test('valid with aspectRatio', () => {
+    const result = frameEmbedNextSchema.safeParse({
+      ...baseEmbed,
+      version: '1',
+      aspectRatio: '1:1',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('imageUrl must be secure URL', () => {
+    const result = frameEmbedNextSchema.safeParse({
+      ...baseEmbed,
+      version: '1',
+      imageUrl: 'http://example.com/image.png', // not https
+    })
+    expect(result.success).toBe(false)
   })
 })

--- a/site/pages/docs/guides/sharing.mdx
+++ b/site/pages/docs/guides/sharing.mdx
@@ -45,7 +45,7 @@ to render a rich card.
 
 ### `version`
 
-The string literal `'next'`.
+The string literal `'1'`.
 
 
 ### `imageUrl`
@@ -91,7 +91,7 @@ Splash image Color. Defaults to `splashBackgroundColor` specified in your applic
 
 ```typescript
 const frame = {
-  version: "next",
+  version: "1",
   imageUrl: "https://yoink.party/framesV2/opengraph-image",
   button: {
     title: "🚩 Start",
@@ -110,7 +110,7 @@ const frame = {
 <html lang="en">
   <head>
     <!-- head content -->
-    <meta name="fc:frame" content='{"version":"next","imageUrl":"https://yoink.party/framesV2/opengraph-image","button":{"title":"🚩 Start","action":{"type":"launch_frame","name":"Yoink!","url":"https://yoink.party/framesV2","splashImageUrl":"https://yoink.party/logo.png","splashBackgroundColor":"#f5f0ec"}}}' />
+    <meta name="fc:frame" content='{"version":"1","imageUrl":"https://yoink.party/framesV2/opengraph-image","button":{"title":"🚩 Start","action":{"type":"launch_frame","name":"Yoink!","url":"https://yoink.party/framesV2","splashImageUrl":"https://yoink.party/logo.png","splashBackgroundColor":"#f5f0ec"}}}' />
   </head>
   <body>
     <!-- page content -->

--- a/site/pages/docs/specification.mdx
+++ b/site/pages/docs/specification.mdx
@@ -34,8 +34,8 @@ A Mini App URL must have a FrameEmbed in a serialized form in the `fc:frame` met
 
 | Property | Type   | Required | Description             | Constraints                                   |
 |----------|--------|----------|-------------------------|-----------------------------------------------|
-| version  | string | Yes      | Version of the embed.   | Must be "1" or "next"                         |
-| imageUrl | string | Yes      | Image url for the embed | Max 1024 characters. Must be 3:2 aspect ratio. |
+| version  | string | Yes      | Version of the embed.   | Must be "1"                                   |
+| imageUrl | string | Yes      | Image url for the embed | Max 1024 characters. Must be 3:2 aspect ratio.|
 | button   | object | Yes      | Button                  |                                               |
 
 #### Button Schema
@@ -62,7 +62,7 @@ A Mini App URL must have a FrameEmbed in a serialized form in the `fc:frame` met
 
 ```json
 {
-  "version": "next",
+  "version": "1",
   "imageUrl": "https://yoink.party/framesV2/opengraph-image",
   "button": {
     "title": "🚩 Start",


### PR DESCRIPTION
We had inconsistently said version `next` or `1` was accepted but only accepted `next`.

Having a version of `next` isn't helpful since the only reason to change this schema version is for a backwards incompatible change. Accept both for `1` but use `1` everywhere in the docs.