### PR TITLE
update docs to use next for embed schema

### DIFF
--- a/packages/frame-core/src/schemas/embeds.ts
+++ b/packages/frame-core/src/schemas/embeds.ts
@@ -32,7 +32,7 @@ export const buttonSchema = z.object({
 })
 
 export const frameEmbedNextSchema = z.object({
-  version: z.union([z.literal('next'), z.literal('1')]),
+  version: z.literal('next'),
   imageUrl: secureUrlSchema,
   aspectRatio: aspectRatioSchema.optional(),
   button: buttonSchema,

--- a/packages/frame-core/tests/schemas/embeds.test.ts
+++ b/packages/frame-core/tests/schemas/embeds.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'vitest'
 import {
   actionLaunchFrameSchema,
   actionSchema,
-  frameEmbedNextSchema,
 } from '../../src/schemas/embeds.ts'
 
 describe('actionLaunchFrameSchema', () => {
@@ -76,65 +75,5 @@ describe('actionViewTokenSchema', () => {
       })
       expect(result.success, `Expected invalid CAIP-19: ${id}`).toBe(false)
     }
-  })
-})
-
-describe('frameEmbedNextSchema', () => {
-  const baseEmbed = {
-    imageUrl: 'https://example.com/image.png',
-    button: {
-      title: 'Click me',
-      action: {
-        type: 'launch_frame' as const,
-        name: 'Test',
-        url: 'https://example.com/frame',
-      },
-    },
-  }
-
-  test('valid with version "next"', () => {
-    const result = frameEmbedNextSchema.safeParse({
-      ...baseEmbed,
-      version: 'next',
-    })
-    expect(result.success).toBe(true)
-  })
-
-  test('valid with version "1"', () => {
-    const result = frameEmbedNextSchema.safeParse({
-      ...baseEmbed,
-      version: '1',
-    })
-    expect(result.success).toBe(true)
-  })
-
-  test('invalid with other version values', () => {
-    const invalidVersions = ['0', '2', '0.0.1', 'v1', 'latest']
-
-    for (const version of invalidVersions) {
-      const result = frameEmbedNextSchema.safeParse({
-        ...baseEmbed,
-        version,
-      })
-      expect(result.success, `Expected invalid version: ${version}`).toBe(false)
-    }
-  })
-
-  test('valid with aspectRatio', () => {
-    const result = frameEmbedNextSchema.safeParse({
-      ...baseEmbed,
-      version: '1',
-      aspectRatio: '1:1',
-    })
-    expect(result.success).toBe(true)
-  })
-
-  test('imageUrl must be secure URL', () => {
-    const result = frameEmbedNextSchema.safeParse({
-      ...baseEmbed,
-      version: '1',
-      imageUrl: 'http://example.com/image.png', // not https
-    })
-    expect(result.success).toBe(false)
   })
 })

--- a/site/pages/docs/specification.mdx
+++ b/site/pages/docs/specification.mdx
@@ -34,7 +34,7 @@ A Mini App URL must have a FrameEmbed in a serialized form in the `fc:frame` met
 
 | Property | Type   | Required | Description             | Constraints                                   |
 |----------|--------|----------|-------------------------|-----------------------------------------------|
-| version  | string | Yes      | Version of the embed.   | Must be "1"                                   |
+| version  | string | Yes      | Version of the embed.   | Must be "next"                                |
 | imageUrl | string | Yes      | Image url for the embed | Max 1024 characters. Must be 3:2 aspect ratio.|
 | button   | object | Yes      | Button                  |                                               |
 


### PR DESCRIPTION
"1" is accepted in the latest schemas but won't work in existing ones. Revert the docs changes so devs don't put in a value that won't be accepted. Can flip these back later.