### PR TITLE
backwards compatible addMiniApp

### DIFF
--- a/.changeset/ready-streets-tan.md
+++ b/.changeset/ready-streets-tan.md
@@ -1,0 +1,7 @@
+---
+"@farcaster/miniapp-core": patch
+"@farcaster/miniapp-host": patch
+"@farcaster/miniapp-sdk": patch
+---
+
+Made addMiniApp backwards compatible.

--- a/packages/miniapp-core/src/types.ts
+++ b/packages/miniapp-core/src/types.ts
@@ -84,6 +84,7 @@ export type WireMiniAppHost = {
   ethProviderRequestV2: Ethereum.RpcTransport
   eip6963RequestProvider: () => void
   solanaProviderRequest?: SolanaWireRequestFn
+  addFrame: AddMiniApp.WireAddMiniApp
   addMiniApp: AddMiniApp.WireAddMiniApp
   viewCast: ViewCast.ViewCast
   viewProfile: ViewProfile.ViewProfile
@@ -116,6 +117,7 @@ export type MiniAppHost = {
    */
   eip6963RequestProvider: () => void
   solanaProviderRequest?: SolanaRequestFn
+  addFrame: AddMiniApp.AddMiniApp
   addMiniApp: AddMiniApp.AddMiniApp
   viewCast: ViewCast.ViewCast
   viewProfile: ViewProfile.ViewProfile

--- a/packages/miniapp-host/src/helpers/endpoint.ts
+++ b/packages/miniapp-host/src/helpers/endpoint.ts
@@ -20,7 +20,7 @@ export function exposeToEndpoint({
   debug = false,
 }: {
   endpoint: HostEndpoint
-  sdk: Omit<MiniAppHost, 'ethProviderRequestV2'>
+  sdk: Omit<MiniAppHost, 'ethProviderRequestV2' | 'addFrame'>
   miniAppOrigin: string
   ethProvider?: Provider.Provider
   debug?: boolean

--- a/packages/miniapp-host/src/helpers/sdk.ts
+++ b/packages/miniapp-host/src/helpers/sdk.ts
@@ -8,6 +8,30 @@ import {
 export function wrapHandlers(host: MiniAppHost): WireMiniAppHost {
   return {
     ...host,
+    addFrame: async () => {
+      try {
+        const result = await host.addMiniApp()
+        return { result }
+      } catch (e) {
+        if (e instanceof AddMiniApp.RejectedByUser) {
+          return {
+            error: {
+              type: 'rejected_by_user',
+            },
+          }
+        }
+
+        if (e instanceof AddMiniApp.InvalidDomainManifest) {
+          return {
+            error: {
+              type: 'invalid_domain_manifest',
+            },
+          }
+        }
+
+        throw e
+      }
+    },
     addMiniApp: async () => {
       try {
         const result = await host.addMiniApp()

--- a/packages/miniapp-sdk/src/sdk.ts
+++ b/packages/miniapp-sdk/src/sdk.ts
@@ -55,7 +55,9 @@ async function isInMiniApp(timeoutMs = 50): Promise<boolean> {
 }
 
 const addMiniApp = async () => {
-  const response = await miniAppHost.addMiniApp()
+  // Use the existing message overcomlink for backwards compat until
+  // hosts are all upgraded.
+  const response = await miniAppHost.addFrame()
   if (response.result) {
     return response.result
   }


### PR DESCRIPTION
Update addMiniApp to use the backwards compatible addFrame until Farcaster, Coinbase Wallet, and any other clients upgrade to the latest host.