### PR TITLE
feat: add openMiniApp action and related documentation

### DIFF
--- a/site/pages/docs/getting-started.mdx
+++ b/site/pages/docs/getting-started.mdx
@@ -27,6 +27,23 @@ Before getting started, make sure you have:
 If you encounter installation errors, verify you're using Node.js 22.11.0 or higher. Earlier versions are not supported.
 :::
 
+## Enable Developer Mode
+
+Before you can publish Mini Apps, you need to enable developer mode in Farcaster:
+
+1. Make sure you're logged in to Farcaster on either mobile or desktop
+2. Click this link: [https://farcaster.xyz/~/settings/developer-tools](https://farcaster.xyz/~/settings/developer-tools) on either mobile or desktop.
+3. Toggle on "Developer Mode"
+4. Once enabled, a developer section will appear on the left side of your desktop display
+
+:::tip
+Developer mode gives you access to tools for creating manifests, previewing your mini app, auditing your manifests and embeds, and viewing analytics.
+:::
+
+:::info
+We recommend using developer mode on desktop as it provides better functionality and a more comprehensive development experience.
+:::
+
 ## Quick Start
 
 For new projects, you can set up an app using the

--- a/site/pages/docs/sdk/actions/open-miniapp.mdx
+++ b/site/pages/docs/sdk/actions/open-miniapp.mdx
@@ -1,0 +1,139 @@
+---
+title: openMiniApp
+description: Opens another Mini App
+---
+
+import { Caption } from '../../../../components/Caption.tsx';
+
+# openMiniApp
+
+Opens another Mini App, providing a seamless way to navigate between Mini Apps within the Farcaster ecosystem.
+
+When you open another Mini App using this method, your current Mini App will close after successful navigation. The target Mini App will receive information about your app as the referrer, enabling referral tracking and app-to-app flows.
+
+## Usage
+
+```ts twoslash
+const options = {
+  url: 'https://www.bountycaster.xyz/bounty/0x983ad3e340fbfef785e0705ff87c0e63c22bebc4'
+};
+
+//---cut---
+import { sdk } from '@farcaster/miniapp-sdk'
+
+// Open a Mini App using an embed URL
+await sdk.actions.openMiniApp({
+  url: 'https://www.bountycaster.xyz/bounty/0x983ad3e340fbfef785e0705ff87c0e63c22bebc4'
+})
+
+// Open a Mini App using a launch URL
+await sdk.actions.openMiniApp({
+  url: 'https://farcaster.xyz/miniapps/WoLihpyQDh7w/farville'
+})
+```
+
+## Options
+
+```ts
+type OpenMiniAppOptions = {
+  url: string
+}
+```
+
+- `url`: The URL of the Mini App to open. This can be either:
+  - A Mini App embed URL (e.g., `https://example.com/specific-page`)
+  - A Mini App launch URL (e.g., `https://farcaster.xyz/miniapps/[id]/[name]`)
+
+## Return Value
+
+`Promise<void>` - The promise resolves when navigation is successful. If navigation fails, the promise will be rejected with an error.
+
+## Error Handling
+
+Always await the `openMiniApp` call and handle potential errors:
+
+```ts
+import { sdk } from '@farcaster/miniapp-sdk'
+
+try {
+  await sdk.actions.openMiniApp({
+    url: 'https://example.com/miniapp'
+  })
+  // Navigation successful - your app will close
+} catch (error) {
+  console.error('Failed to open Mini App:', error)
+  // Handle the error - your app remains open
+}
+```
+
+## Referrer Information
+
+When a Mini App is opened using `openMiniApp`, the target app receives a special location context with referrer information:
+
+```ts
+// In the target Mini App:
+if (sdk.context.location?.type === 'open_miniapp') {
+  console.log('Referred by:', sdk.context.location.referrerDomain)
+  // e.g., "Referred by: yourminiapp.com"
+}
+```
+
+## Use Cases
+
+### Hub or Portfolio Apps
+
+Create a central hub that showcases multiple Mini Apps:
+
+```ts
+const miniApps = [
+  { name: 'Farville', url: 'https://farcaster.xyz/miniapps/WoLihpyQDh7w/farville' },
+  { name: 'Bountycaster', url: 'https://www.bountycaster.xyz' },
+  { name: 'Yoink', url: 'https://yoink.party/framesV2/' }
+]
+
+function MiniAppHub() {
+  const handleOpenApp = async (url: string) => {
+    try {
+      await sdk.actions.openMiniApp({ url })
+    } catch (error) {
+      console.error('Failed to open app:', error)
+    }
+  }
+
+  return (
+    <div>
+      {miniApps.map(app => (
+        <button key={app.name} onClick={() => handleOpenApp(app.url)}>
+          Open {app.name}
+        </button>
+      ))}
+    </div>
+  )
+}
+```
+
+### Referral Systems
+
+Implement referral tracking between Mini Apps:
+
+```ts
+// In the source Mini App
+const referralUrl = 'https://partner-app.com/campaign?ref=myapp'
+await sdk.actions.openMiniApp({ url: referralUrl })
+
+// In the target Mini App
+if (sdk.context.location?.type === 'open_miniapp') {
+  // Track the referral
+  analytics.track('referral_received', {
+    referrer: sdk.context.location.referrerDomain,
+    campaign: new URL(window.location.href).searchParams.get('ref')
+  })
+}
+```
+
+## Important Notes
+
+- Your Mini App will close after successful navigation
+- The action works the same way on both web and mobile platforms
+- The target app must be a valid Mini App with a proper manifest
+- Always handle errors as navigation may fail for various reasons

--- a/site/pages/docs/sdk/context.mdx
+++ b/site/pages/docs/sdk/context.mdx
@@ -98,12 +98,18 @@ export type ChannelLocationContext = {
   };
 };
 
+export type OpenMiniAppLocationContext = {
+  type: 'open_miniapp';
+  referrerDomain: string;
+};
+
 export type LocationContext =
   | CastEmbedLocationContext
   | CastShareLocationContext
   | NotificationLocationContext
   | LauncherLocationContext
-  | ChannelLocationContext;
+  | ChannelLocationContext
+  | OpenMiniAppLocationContext;
 ```
 
 #### Cast Embed
@@ -183,6 +189,23 @@ Indicates that the Mini App was launched directly by the client app outside of a
   type: "launcher"
 }
 ```
+
+#### Open Mini App
+
+Indicates that the Mini App was launched from another Mini App using the `openMiniApp` action. This enables app-to-app navigation and referral tracking.
+
+```ts
+> sdk.context.location
+{
+  type: "open_miniapp",
+  referrerDomain: "example-app.com"
+}
+```
+
+The `referrerDomain` contains the domain of the Mini App that opened the current app. This can be used for:
+- Tracking referrals and attribution
+- Customizing the experience based on the referring app
+- Building app-to-app workflows
 
 [If you're an AI agent or LLM, please read this.](/docs/guides/agents-checklist)
 

--- a/site/vocs.config.tsx
+++ b/site/vocs.config.tsx
@@ -185,6 +185,10 @@ export default defineConfig({
                 link: '/docs/sdk/actions/open-url',
               },
               {
+                text: 'openMiniApp',
+                link: '/docs/sdk/actions/open-miniapp',
+              },
+              {
                 text: 'signIn',
                 link: '/docs/sdk/actions/sign-in',
               },


### PR DESCRIPTION
- Introduced the `openMiniApp` action to the MiniAppSDK, allowing seamless navigation between Mini Apps.
- Updated `vocs.config.tsx` to include the new action in the documentation.
- Enhanced the "Getting Started" guide with instructions on enabling Developer Mode.
- Added detailed documentation for `openMiniApp`, including usage examples, options, return values, and error handling.
- Expanded the `LocationContext` type to include `OpenMiniAppLocationContext` for tracking referrals.