### PR TITLE
Enhance documentation on `addMiniApp()` action and domain requirements

### DIFF
--- a/site/pages/docs/guides/agents-checklist.mdx
+++ b/site/pages/docs/guides/agents-checklist.mdx
@@ -244,6 +244,13 @@ await sdk.actions.ready()
 1. Open tunnel URL directly in browser first
 2. Then use in preview tool
 3. This whitelists the domain for iframe usage
+
+**Important Limitations:**
+
+- SDK actions like `addMiniApp()` will fail with tunnel domains
+- Your manifest domain must match your app's hosting domain exactly
+- Tunnel domains are excluded from discovery/search
+- For testing `addMiniApp()` and other manifest-dependent features, deploy to your production domain
 </details>
 
 ---

--- a/site/pages/docs/guides/notifications.mdx
+++ b/site/pages/docs/guides/notifications.mdx
@@ -102,9 +102,9 @@ enabled by default).
 Use the [addMiniApp](/docs/sdk/actions/add-miniapp) action while a user is using your app to prompt
 them to add it:
 
-:::warning
+### Caution
+
 The `addMiniApp()` action only works when your app is deployed to its production domain (matching your manifest). It will not work with tunnel domains during development.
-:::
 
 
 ### Save the notification tokens

--- a/site/pages/docs/sdk/actions/add-miniapp.mdx
+++ b/site/pages/docs/sdk/actions/add-miniapp.mdx
@@ -24,13 +24,11 @@ import { sdk } from '@farcaster/miniapp-sdk'
 await sdk.actions.addMiniApp()
 ```
 
-:::caution
 The `addMiniApp()` action requires your app's domain to exactly match the domain in your manifest file. This means:
 
 - You cannot use tunnel domains (ngrok, localtunnel, etc.) - the action will fail
 - Your app must be deployed to the same domain specified in your `farcaster.json`
 - For local development, use the preview tool instead of trying to add the app
-:::
 
 ## Return Value
 

--- a/site/snippets/exposeLocalhost.mdx
+++ b/site/snippets/exposeLocalhost.mdx
@@ -47,7 +47,6 @@ When using a tunnel URL for the first time, you must open it in your browser bef
 2. You should see your local application
 3. Now the URL can be used in the Mini App preview tool or embed debugger
 
-:::warning
 **Tunnel domains are for development only**. When using tunnel services like ngrok or cloudflared:
 
 - SDK actions like `addMiniApp()` will fail with tunnel domains


### PR DESCRIPTION
- Added warnings about the necessity of using production domains for the `addMiniApp()` action in both the notifications and add-miniapp documentation.
- Clarified that tunnel domains are not supported and provided guidance for local development.
- Updated the exposeLocalhost snippet to emphasize domain limitations when using tunnel services.