### PR TITLE
Add Mini App Preview tool step to 'How do I test my Mini App locally?' faq

### DIFF
--- a/site/pages/docs/guides/faq.mdx
+++ b/site/pages/docs/guides/faq.mdx
@@ -58,6 +58,7 @@ Currently, you need to use tunneling tools like ngrok to expose your local serve
 1. **Node.js version**: Use Node.js 22.11.0 or higher
 2. **Tunneling**: Use ngrok or similar tools to create HTTPS URLs
 3. **HTTPS required**: Farcaster requires HTTPS for Mini Apps
+4. **Test your app**: Use the [Mini App Preview Tool](https://farcaster.xyz/~/developers/mini-apps/preview) to test the app at your tunneled URL
 
 ## My manifest isn't validating. What's wrong?
 


### PR DESCRIPTION
A member of my team was asking about the process to run mini apps locally. If this step had been in the docs - I could have just linked him to the faq item.

It may seem obvious but it's a tool nested within a menu item which is not enabled for Farcaster users by default.

~ Jeffrey (Computer Operator)