### PR TITLE
chore: update Base App incompatibilities in compatibility.mdx

### DIFF
--- a/site/pages/docs/sdk/compatibility.mdx
+++ b/site/pages/docs/sdk/compatibility.mdx
@@ -11,12 +11,7 @@ This guide tracks known incompatibilities as we work towards that goal.
 
 ## Base App
 
-Below is a list of the main incompatibilities Base App is actively working on fixing. For more information on how mini apps work in Base App, please refer to [these docs](https://docs.base.org/base-app/introduction/mini-apps).
+Below is a list of the main incompatibilities Base App is actively working on fixing. For more information on how mini apps work in Base App, please refer to [these docs](https://docs.base.org/mini-apps).
 
-- `sdk.actions.composeCast()` bug fixes for return data (ETA 8/6)
-- `sdk.isInMiniApp()` (ETA 8/6)
-- `sdk.actions.swapToken()` (ETA 8/6)
-- `sdk.actions.addMiniApp()` (ETA 8/13)
-- `sdk.back` methods (ETA 8/13)
-- `sdk.haptics` methods (ETA 8/13)
-- `sdk.actions.requestCameraAndMicrophoneAccess()` (ETA 8/13)
+- `sdk.actions.addMiniApp` (ETA early October, more info soon!)
+- `sdk.experimental.signManifest` (ETA early October, more info soon!)


### PR DESCRIPTION
This PR updates the [Compatibility](https://miniapps.farcaster.xyz/docs/sdk/compatibility) page with the latest information on mini app incompatibilities in [Base App](https://base.app), as many of those issues have been fixed in Base App recently.

A small note to reviewers is that I understand more exact ETAs would be helpful here, as soon as there are more exact dates to share I'm happy to add them to this page!