### PR TITLE
refactor: update package.json and tsconfig files for better esm and cjs bundling

### DIFF
--- a/packages/miniapp-node/package.json
+++ b/packages/miniapp-node/package.json
@@ -7,14 +7,9 @@
     "url": "https://github.com/farcasterxyz/frames.git",
     "directory": "packages/miniapp-node"
   },
-  "exports": {
-    ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js"
-    }
-  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "clean": "rm -rf dist esm",
     "prebuild": "npm run clean",

--- a/packages/miniapp-node/package.json
+++ b/packages/miniapp-node/package.json
@@ -7,14 +7,21 @@
     "url": "https://github.com/farcasterxyz/frames.git",
     "directory": "packages/miniapp-node"
   },
-  "main": "dist/index.js",
-  "module": "esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    }
+  },
   "scripts": {
     "clean": "rm -rf dist esm",
     "prebuild": "npm run clean",
-    "build": "pnpm build:cjs & pnpm build:esm",
+    "build": "pnpm build:cjs & pnpm build:esm & pnpm build:types",
     "build:cjs": "tsc -p tsconfig.node.json",
     "build:esm": "tsc -p tsconfig.json",
+    "build:types": "tsc -p tsconfig.json --declaration --emitDeclarationOnly --outDir dist/types",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -22,7 +29,6 @@
   },
   "files": [
     "dist",
-    "esm",
     "src"
   ],
   "devDependencies": {

--- a/packages/miniapp-node/package.json
+++ b/packages/miniapp-node/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "clean": "rm -rf dist esm",
     "prebuild": "npm run clean",
-    "build": "pnpm build:cjs & pnpm build:esm & pnpm build:types",
+    "build": "pnpm build:types && pnpm build:cjs && pnpm build:esm",
     "build:cjs": "tsc -p tsconfig.node.json",
     "build:esm": "tsc -p tsconfig.json",
     "build:types": "tsc -p tsconfig.json --declaration --emitDeclarationOnly --outDir dist/types",

--- a/packages/miniapp-node/tsconfig.json
+++ b/packages/miniapp-node/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "@farcaster/tsconfig/browser.json",
   "include": ["src"],
-  "exclude": ["esm", "dist", "build", "node_modules"],
+  "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
-    "outDir": "esm"
+    "outDir": "dist/esm",
+    "declaration": false,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   }
 }

--- a/packages/miniapp-node/tsconfig.node.json
+++ b/packages/miniapp-node/tsconfig.node.json
@@ -1,9 +1,9 @@
 {
   "extends": "@farcaster/tsconfig/node.json",
   "include": ["src"],
-  "exclude": ["esm", "dist", "build", "node_modules"],
+  "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist/cjs",
+    "declaration": false
   }
 }
-

--- a/packages/miniapp-node/turbo.json
+++ b/packages/miniapp-node/turbo.json
@@ -2,7 +2,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "outputs": [".dist/**", "esm/**"]
+      "outputs": [".dist/**"]
     }
   }
 }


### PR DESCRIPTION
### Fix for Issue #486

This pull request addresses the issue caused by the Node.js environment incorrectly interpreting ESM exports as CJS exports. This misinterpretation led to problems with process.env, resulting in environment variables not propagating correctly between different contexts.

Changes Made:
- Updated the build process to out into (dist/esm, dist/cjs, dist/types) hence type exports come from a single source
- Updated the package.json to use the latest export conventions from npm. Hence runtime is strictly instructed to use same export throughout the instance

Note:
This might be happening because we are running bun in ts mode in prod, (which is a production ready usecase)

These changes should improve the handling of environment variables and prevent context switching issues.