### PR TITLE
feat: upgrade zod to v4

### DIFF
--- a/.changeset/sour-comics-thank.md
+++ b/.changeset/sour-comics-thank.md
@@ -1,0 +1,8 @@
+---
+"@farcaster/miniapp-core": minor
+"@farcaster/miniapp-node": minor
+"@farcaster/frame-core": minor
+"@farcaster/frame-node": minor
+---
+
+Upgrade zod to v4.

--- a/packages/frame-core/package.json
+++ b/packages/frame-core/package.json
@@ -32,7 +32,7 @@
     "@farcaster/miniapp-core": "workspace:*",
     "@solana/web3.js": "^1.98.2",
     "ox": "^0.4.4",
-    "zod": "^3.24.1"
+    "zod": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/frame-node/package.json
+++ b/packages/frame-node/package.json
@@ -33,7 +33,7 @@
     "@farcaster/miniapp-node": "workspace:*",
     "@noble/curves": "^1.7.0",
     "ox": "^0.4.4",
-    "zod": "^3.24.1"
+    "zod": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/miniapp-core/package.json
+++ b/packages/miniapp-core/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@solana/web3.js": "^1.98.2",
     "ox": "^0.4.4",
-    "zod": "^3.25.0"
+    "zod": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/miniapp-core/src/schemas/embeds.ts
+++ b/packages/miniapp-core/src/schemas/embeds.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 import {
   aspectRatioSchema,
   buttonTitleSchema,

--- a/packages/miniapp-core/src/schemas/events.ts
+++ b/packages/miniapp-core/src/schemas/events.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 import { notificationDetailsSchema } from './notifications.ts'
 
 export const eventMiniAppAddedSchema = z.object({

--- a/packages/miniapp-core/src/schemas/manifest.ts
+++ b/packages/miniapp-core/src/schemas/manifest.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 import { miniAppHostCapabilityList } from '../types.ts'
 import {
   buttonTitleSchema,

--- a/packages/miniapp-core/src/schemas/notifications.ts
+++ b/packages/miniapp-core/src/schemas/notifications.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 import { secureUrlSchema } from './shared.ts'
 
 export const notificationDetailsSchema = z.object({

--- a/packages/miniapp-core/src/schemas/shared.ts
+++ b/packages/miniapp-core/src/schemas/shared.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 const SPECIAL_CHARS_PATTERN = /[@#$%^&*+=/\\|~«»]/
 const REPEATED_PUNCTUATION_PATTERN = /(!{2,}|\?{2,}|-{2,})/

--- a/packages/miniapp-node/package.json
+++ b/packages/miniapp-node/package.json
@@ -36,7 +36,7 @@
     "@farcaster/miniapp-core": "workspace:*",
     "@noble/curves": "^1.7.0",
     "ox": "^0.4.4",
-    "zod": "^3.24.1"
+    "zod": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/miniapp-node/src/farcaster.ts
+++ b/packages/miniapp-node/src/farcaster.ts
@@ -1,5 +1,5 @@
 import * as AbiParameters from 'ox/AbiParameters'
-import { z } from 'zod'
+import * as z from 'zod'
 import {
   BaseError,
   type VerifyAppKey,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,10 +152,10 @@ importers:
         version: 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       ox:
         specifier: ^0.4.4
-        version: 0.4.4(typescript@5.8.3)(zod@3.25.7)
+        version: 0.4.4(typescript@5.8.3)(zod@4.1.12)
       zod:
-        specifier: ^3.24.1
-        version: 3.25.7
+        specifier: ^4.0.0
+        version: 4.1.12
     devDependencies:
       '@farcaster/tsconfig':
         specifier: workspace:*
@@ -230,10 +230,10 @@ importers:
         version: 1.9.1
       ox:
         specifier: ^0.4.4
-        version: 0.4.4(typescript@5.8.3)(zod@3.25.7)
+        version: 0.4.4(typescript@5.8.3)(zod@4.1.12)
       zod:
-        specifier: ^3.24.1
-        version: 3.25.7
+        specifier: ^4.0.0
+        version: 4.1.12
     devDependencies:
       '@farcaster/tsconfig':
         specifier: workspace:*
@@ -351,10 +351,10 @@ importers:
         version: 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       ox:
         specifier: ^0.4.4
-        version: 0.4.4(typescript@5.8.3)(zod@3.25.56)
+        version: 0.4.4(typescript@5.8.3)(zod@4.1.12)
       zod:
-        specifier: ^3.25.0
-        version: 3.25.56
+        specifier: ^4.0.0
+        version: 4.1.12
     devDependencies:
       '@farcaster/tsconfig':
         specifier: workspace:*
@@ -429,10 +429,10 @@ importers:
         version: 1.9.1
       ox:
         specifier: ^0.4.4
-        version: 0.4.4(typescript@5.8.3)(zod@3.25.56)
+        version: 0.4.4(typescript@5.8.3)(zod@4.1.12)
       zod:
-        specifier: ^3.24.1
-        version: 3.25.56
+        specifier: ^4.0.0
+        version: 4.1.12
     devDependencies:
       '@farcaster/tsconfig':
         specifier: workspace:*
@@ -8570,14 +8570,11 @@ packages:
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
-  zod@3.24.1:
-    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
-
   zod@3.25.56:
     resolution: {integrity: sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==}
 
-  zod@3.25.7:
-    resolution: {integrity: sha512-YGdT1cVRmKkOg6Sq7vY7IkxdphySKnXhaUmFI4r4FcuFVNgpCb9tZfNwXbT6BPjD5oz0nubFsoo9pIqKrDcCvg==}
+  zod@4.1.12:
+    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
 
   zustand@5.0.0:
     resolution: {integrity: sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==}
@@ -11029,7 +11026,7 @@ snapshots:
     dependencies:
       jose: 5.10.0
       typescript: 5.9.2
-      zod: 3.25.7
+      zod: 3.25.56
 
   '@farcaster/quick-auth@0.0.6(typescript@5.8.3)':
     dependencies:
@@ -14204,7 +14201,7 @@ snapshots:
       '@metamask/sdk': 0.32.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56)
-      '@wagmi/core': 2.17.2(@tanstack/query-core@5.76.0)(@types/react@19.1.4)(react@19.1.0)(typescript@5.8.3)(viem@2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56))
+      '@wagmi/core': 2.17.2(@tanstack/query-core@5.76.0)(@types/react@19.1.4)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56))
       '@walletconnect/ethereum-provider': 2.20.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.79.2(@babel/core@7.27.1)(@types/react@19.1.4)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@types/react@19.1.4)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
       viem: 2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56)
@@ -14267,7 +14264,7 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@2.17.2(@tanstack/query-core@5.76.0)(@types/react@19.1.4)(react@19.1.0)(typescript@5.8.3)(viem@2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56))':
+  '@wagmi/core@2.17.2(@tanstack/query-core@5.76.0)(@types/react@19.1.4)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.8.3)
@@ -15288,10 +15285,10 @@ snapshots:
       typescript: 5.8.3
       zod: 3.25.56
 
-  abitype@1.0.8(typescript@5.8.3)(zod@3.25.7):
+  abitype@1.0.8(typescript@5.8.3)(zod@4.1.12):
     optionalDependencies:
       typescript: 5.8.3
-      zod: 3.25.7
+      zod: 4.1.12
 
   abitype@1.0.8(typescript@5.9.2)(zod@3.22.4):
     optionalDependencies:
@@ -17486,8 +17483,8 @@ snapshots:
       smol-toml: 1.3.1
       strip-json-comments: 5.0.1
       typescript: 5.8.3
-      zod: 3.24.1
-      zod-validation-error: 3.4.0(zod@3.24.1)
+      zod: 3.25.56
+      zod-validation-error: 3.4.0(zod@3.25.56)
 
   kolorist@1.8.0: {}
 
@@ -18744,14 +18741,14 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.4.4(typescript@5.8.3)(zod@3.25.7):
+  ox@0.4.4(typescript@5.8.3)(zod@4.1.12):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.8.3)(zod@3.25.7)
+      abitype: 1.0.8(typescript@5.8.3)(zod@4.1.12)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.8.3
@@ -20895,7 +20892,7 @@ snapshots:
     dependencies:
       '@tanstack/react-query': 5.76.1(react@19.1.0)
       '@wagmi/connectors': 5.8.3(@react-native-async-storage/async-storage@1.24.0(react-native@0.79.2(@babel/core@7.27.1)(@types/react@19.1.4)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@types/react@19.1.4)(@wagmi/core@2.17.2(@tanstack/query-core@5.76.0)(@types/react@19.1.4)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56)))(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56))(zod@3.25.56)
-      '@wagmi/core': 2.17.2(@tanstack/query-core@5.76.0)(@types/react@19.1.4)(react@19.1.0)(typescript@5.8.3)(viem@2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56))
+      '@wagmi/core': 2.17.2(@tanstack/query-core@5.76.0)(@types/react@19.1.4)(react@19.1.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56))
       react: 19.1.0
       use-sync-external-store: 1.4.0(react@19.1.0)
       viem: 2.30.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.56)
@@ -21108,19 +21105,17 @@ snapshots:
       mustache: 4.2.0
       stacktracey: 2.1.8
 
-  zod-validation-error@3.4.0(zod@3.24.1):
+  zod-validation-error@3.4.0(zod@3.25.56):
     dependencies:
-      zod: 3.24.1
+      zod: 3.25.56
 
   zod@3.22.3: {}
 
   zod@3.22.4: {}
 
-  zod@3.24.1: {}
-
   zod@3.25.56: {}
 
-  zod@3.25.7: {}
+  zod@4.1.12: {}
 
   zustand@5.0.0(@types/react@19.1.13)(react@19.1.1)(use-sync-external-store@1.4.0(react@19.1.1)):
     optionalDependencies:


### PR DESCRIPTION
There are many pkgs in the ecosystem that have been upgraded to zod v4. And the farcaster pkgs are one of the latest to use zod v3 creating issues in our pnpm monorepo with conflicting versions.
Wdyt about upgrading the dependency? Thanks.