### PR TITLE
fix: add ?bundle parameter to esm.sh CDN URLs

### DIFF
--- a/site/pages/docs/getting-started.mdx
+++ b/site/pages/docs/getting-started.mdx
@@ -98,7 +98,7 @@ the bottom of your HTML file with the following content.
 
 ```html
 <script type="module">
-  import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk'
+  import { sdk } from 'https://esm.sh/@farcaster/miniapp-sdk?bundle'
 </script>
 ```
 

--- a/site/pages/docs/sdk/quick-auth/index.mdx
+++ b/site/pages/docs/sdk/quick-auth/index.mdx
@@ -71,7 +71,7 @@ acquired.
 
 <script type="module">
   import ky from "https://esm.sh/ky";
-  import { sdk } from "https://esm.sh/@farcaster/miniapp-sdk";
+  import { sdk } from "https://esm.sh/@farcaster/miniapp-sdk?bundle";
 
   const { token } = await sdk.quickAuth.getToken();
   const user = await ky.get("http://localhost:8787" + "/me", {headers: {Authorization: 'Bearer ' + token }}).json();


### PR DESCRIPTION
## Summary
- Add `?bundle` query parameter to all esm.sh CDN imports of `@farcaster/miniapp-sdk`
- Fixes broken CDN imports that started failing this week

## Details
Since this week, importing from `https://esm.sh/@farcaster/miniapp-sdk` without the `?bundle` parameter has stopped working. Adding the `?bundle` query string resolves the issue and ensures the SDK continues to load correctly from the CDN.

## Changes
Updated two documentation files:
- `site/pages/docs/getting-started.mdx`
- `site/pages/docs/sdk/quick-auth/index.mdx`

Both now use `https://esm.sh/@farcaster/miniapp-sdk?bundle` instead of the plain URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)