### PR TITLE
docs: Vercel bot protection and miniapp embed images

### DIFF
--- a/site/pages/docs/guides/agents-checklist.mdx
+++ b/site/pages/docs/guides/agents-checklist.mdx
@@ -201,6 +201,29 @@ export async function generateMetadata({ params }): Promise<Metadata> {
 - Image URL returns 200 and is 3:2 ratio
 - Button title ≤ 32 characters
 
+<details>
+<summary>Embed image missing or gray (Vercel Firewall / Bot Protection)</summary>
+
+**Cause:** Farcaster clients fetch `imageUrl` server-side. Vercel Bot Protection or
+Firewall challenges can block those requests while normal browser traffic still works.
+
+**Mitigations:**
+1. In the Vercel project, add a Firewall rule to **bypass** Bot Protection for the
+   path(s) used only for embed images (for example `/opengraph-image`, `/api/og/*`).
+2. Or host `imageUrl` on a CDN or hostname without bot challenges.
+3. Verify the image URL from a shell (no cookies):
+
+```bash
+curl -sI "https://{domain}/{embed-image-path}" | head -n 8
+```
+
+Expect `HTTP/2 200` and `content-type: image/...`. If the response is HTML or `403`,
+fix hosting or Firewall rules before debugging the client.
+
+Reference: [Sharing guide — Vercel Firewall and Bot Protection](/docs/guides/sharing#vercel-firewall-and-bot-protection)
+
+</details>
+
 ---
 
 ## Check 3: Preview and Runtime

--- a/site/pages/docs/guides/sharing.mdx
+++ b/site/pages/docs/guides/sharing.mdx
@@ -238,3 +238,33 @@ to serve a fallback image.
 
 In this case you should use an extremely short or even 0 `max-age` to prevent the
 error image from getting stuck in any upstream CDNs.
+
+### Vercel Firewall and Bot Protection
+
+Farcaster clients fetch your **`imageUrl`** over HTTPS when building or refreshing
+embed previews. If you host on **Vercel** and enable **Firewall** or **Bot
+Protection**, those requests can be challenged or blocked because they often look
+like automated traffic (no browser session, cookieless, or an unfamiliar user
+agent). The HTML page with `fc:miniapp` may still scrape successfully while the
+image request fails, so you see a broken or gray embed image.
+
+**Mitigations:**
+
+- **Allowlist the image path in Vercel Firewall** — Add a custom rule so requests
+  to your embed image route(s) bypass Bot Protection / challenges (for example paths
+  used only for `imageUrl`, such as `/opengraph-image`, `/api/og`, or `/embed/*.png`).
+  See [Vercel Bot Protection](https://vercel.com/docs/bot-protection) and
+  [Firewall custom rules](https://vercel.com/docs/vercel-firewall) in the Vercel docs.
+- **Serve static embed images from an unprotected origin** — Put PNG/WebP assets on
+  a CDN or hostname without bot challenges and point `imageUrl` there; keep dynamic
+  generation on Vercel only if you can exempt that route.
+- **Verify without a browser** — From a terminal, confirm the URL returns image
+  bytes and not an HTML challenge page:
+
+```bash
+curl -sI "https://your-domain.com/path-to-embed-image.png" | head -n 5
+```
+
+You should see `200` and a `content-type` like `image/png` or `image/jpeg`. If you
+get `403`, a redirect to a challenge, or `text/html`, adjust Firewall rules or
+hosting before relying on that URL in production embeds.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Miniapp embed images can fail when Vercel Firewall or Bot Protection challenges server-side fetches of `imageUrl`. Farcaster clients fetch that URL without a browser session, so it can be blocked while normal page loads still work.

This repository does not implement embed image fetching (that happens in Farcaster clients). The practical fix for app developers is to exempt embed image routes from bot challenges, host static images on an unprotected origin, or verify responses with `curl`.

## Changes

- `site/pages/docs/guides/sharing.mdx`: New subsection **Vercel Firewall and Bot Protection** under Advanced Topics, with mitigations and a `curl` verification snippet.
- `site/pages/docs/guides/agents-checklist.mdx`: Collapsible troubleshooting block under Check 2 (embed metadata) linking to the sharing guide.

## Testing

- Pre-commit `pnpm check` (Biome) passed on commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NEYN-9820](https://linear.app/neynar/issue/NEYN-9820/miniapp-embed-image-fails-when-vercel-firewall-bot-protection-is)

<div><a href="https://cursor.com/agents/bc-1c8ae2fc-b080-48ea-9631-2c3c6b04170f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c8ae2fc-b080-48ea-9631-2c3c6b04170f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

