### PR TITLE
fix(react-native): rebind WebView RPC after Android minimize (NEYN-9910)

### DIFF
--- a/packages/miniapp-host-react-native/src/webviewAdapter.ts
+++ b/packages/miniapp-host-react-native/src/webviewAdapter.ts
@@ -8,12 +8,63 @@ import {
   useMemo,
   useState,
 } from 'react'
+import { AppState, Platform } from 'react-native'
 import type WebView from 'react-native-webview'
 import type { WebViewMessageEvent, WebViewProps } from 'react-native-webview'
 import { createWebViewRpcEndpoint, type WebViewEndpoint } from './webview.ts'
 
 /**
+ * Android can replace the native WebView while the React ref object stays the
+ * same, which would leave Comlink/expose wired to a stale session. Detect
+ * instance changes and bump a tick so callers re-run endpoint setup.
+ */
+function useWebViewNativeInstanceRegenerationTick(
+  webViewRef: RefObject<WebView | null>,
+) {
+  const [tick, setTick] = useState(0)
+  const bump = useCallback(() => setTick((t) => t + 1), [])
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next) => {
+      if (next === 'active') {
+        bump()
+      }
+    })
+    return () => sub.remove()
+  }, [bump])
+
+  useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return
+    }
+
+    let prevNativeInstance: unknown
+    let isFirstSample = true
+
+    const id = setInterval(() => {
+      const cur = webViewRef.current as unknown
+      if (isFirstSample) {
+        isFirstSample = false
+        prevNativeInstance = cur
+        return
+      }
+      if (cur !== prevNativeInstance) {
+        prevNativeInstance = cur
+        bump()
+      }
+    }, 300)
+
+    return () => clearInterval(id)
+  }, [webViewRef, bump])
+
+  return tick
+}
+
+/**
  * Returns a handler of RPC message from WebView.
+ *
+ * @param webViewMountGeneration - Increment when the WebView component remounts
+ *   (e.g. `key` on WebView changes) so the RPC layer re-initializes immediately.
  */
 export function useWebViewRpcAdapter({
   webViewRef,
@@ -21,14 +72,18 @@ export function useWebViewRpcAdapter({
   sdk,
   ethProvider,
   debug = false,
+  webViewMountGeneration = 0,
 }: {
-  webViewRef: RefObject<WebView>
+  webViewRef: RefObject<WebView | null>
   domain: string
   sdk: Omit<MiniAppHost, 'ethProviderRequestV2'>
   ethProvider?: Provider
   debug?: boolean
+  /** Bump when the WebView element remounts so RPC/comlink re-binds without waiting for polling. */
+  webViewMountGeneration?: number
 }) {
   const [endpoint, setEndpoint] = useState<WebViewEndpoint>()
+  const nativeRegenTick = useWebViewNativeInstanceRegenerationTick(webViewRef)
 
   const onMessage: WebViewProps['onMessage'] = useCallback(
     (e: WebViewMessageEvent) => {
@@ -38,8 +93,22 @@ export function useWebViewRpcAdapter({
   )
 
   useEffect(() => {
+    void webViewMountGeneration
+    void nativeRegenTick
     const newEndpoint = createWebViewRpcEndpoint(webViewRef, domain)
     setEndpoint(newEndpoint)
+
+    if (debug) {
+      // biome-ignore lint/suspicious/noConsole: intentional when callers pass debug
+      console.debug(
+        '[miniapp-host-react-native] WebView RPC endpoint (re)initialized',
+        {
+          domain,
+          webViewMountGeneration,
+          nativeRegenTick,
+        },
+      )
+    }
 
     const cleanup = exposeToEndpoint({
       endpoint: newEndpoint,
@@ -53,7 +122,15 @@ export function useWebViewRpcAdapter({
       cleanup?.()
       setEndpoint(undefined)
     }
-  }, [webViewRef, domain, sdk, ethProvider, debug])
+  }, [
+    webViewRef,
+    domain,
+    sdk,
+    ethProvider,
+    debug,
+    webViewMountGeneration,
+    nativeRegenTick,
+  ])
 
   return useMemo(
     () => ({
@@ -68,8 +145,10 @@ export function useWebViewRpcAdapter({
 export function useWebViewRpcEndpoint(
   webViewRef: RefObject<WebView | null>,
   domain: string,
+  webViewMountGeneration = 0,
 ) {
   const [endpoint, setEndpoint] = useState<WebViewEndpoint>()
+  const nativeRegenTick = useWebViewNativeInstanceRegenerationTick(webViewRef)
 
   const onMessage: WebViewProps['onMessage'] = useCallback(
     (e: WebViewMessageEvent) => {
@@ -79,13 +158,15 @@ export function useWebViewRpcEndpoint(
   )
 
   useEffect(() => {
+    void webViewMountGeneration
+    void nativeRegenTick
     const newEndpoint = createWebViewRpcEndpoint(webViewRef, domain)
     setEndpoint(newEndpoint)
 
     return () => {
       setEndpoint(undefined)
     }
-  }, [webViewRef, domain])
+  }, [webViewRef, domain, webViewMountGeneration, nativeRegenTick])
 
   return useMemo(
     () => ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On Android, minimizing a miniapp could leave it stuck minimized because the WebView RPC/Comlink layer stayed bound to a stale native WebView session while `webViewRef` stayed the same object.

## Solution

- **`useWebViewNativeInstanceRegenerationTick`**: bumps a counter when `AppState` returns to `active`, and on Android polls `webViewRef.current` so we detect when the native instance is replaced without the ref object identity changing.
- **`webViewMountGeneration`** (optional): hosts can bump this when remounting the WebView (e.g. `key` change) for immediate re-init without waiting for polling.
- **`debug` logging**: when `debug` is true, log each endpoint (re)initialization with domain and tick values.

## Testing

- `pnpm exec turbo typecheck --filter=@farcaster/miniapp-host-react-native`
- `pnpm exec biome check packages/miniapp-host-react-native/src/webviewAdapter.ts`

Closes NEYN-9910.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NEYN-9910](https://linear.app/neynar/issue/NEYN-9910/android-miniapps-can-get-stuck-in-minimized-mode-only-recoverable-by)

<div><a href="https://cursor.com/agents/bc-b05afc02-5210-4cb0-96a0-968e161322b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b05afc02-5210-4cb0-96a0-968e161322b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

