### PR TITLE
feat(miniapp-core): add failedTokens to sendNotificationResponse [NEYN-10064]

### DIFF
--- a/packages/miniapp-core/src/schemas/notifications.ts
+++ b/packages/miniapp-core/src/schemas/notifications.ts
@@ -26,6 +26,7 @@ export const sendNotificationFailedTokenReasonSchema = z.enum([
   'domain_mismatch',
   'target_url_mismatch',
   'no_webhook_url',
+  'invalid_token',
   'unknown',
 ])
 

--- a/packages/miniapp-core/src/schemas/notifications.ts
+++ b/packages/miniapp-core/src/schemas/notifications.ts
@@ -22,11 +22,33 @@ export type SendNotificationRequest = z.infer<
   typeof sendNotificationRequestSchema
 >
 
+export const sendNotificationFailedTokenReasonSchema = z.enum([
+  'domain_mismatch',
+  'target_url_mismatch',
+  'no_webhook_url',
+  'unknown',
+])
+
+export type SendNotificationFailedTokenReason = z.infer<
+  typeof sendNotificationFailedTokenReasonSchema
+>
+
+export const sendNotificationFailedTokenSchema = z.object({
+  token: z.string(),
+  fid: z.number().int().positive().optional(),
+  reason: sendNotificationFailedTokenReasonSchema,
+})
+
+export type SendNotificationFailedToken = z.infer<
+  typeof sendNotificationFailedTokenSchema
+>
+
 export const sendNotificationResponseSchema = z.object({
   result: z.object({
     successfulTokens: z.array(z.string()),
     invalidTokens: z.array(z.string()),
     rateLimitedTokens: z.array(z.string()),
+    failedTokens: z.array(sendNotificationFailedTokenSchema).optional(),
   }),
 })
 

--- a/packages/miniapp-core/tests/schemas/notifications.test.ts
+++ b/packages/miniapp-core/tests/schemas/notifications.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'vitest'
+import {
+  sendNotificationFailedTokenReasonSchema,
+  sendNotificationFailedTokenSchema,
+  sendNotificationResponseSchema,
+} from '../../src/schemas/notifications.ts'
+
+describe('sendNotificationFailedTokenReasonSchema', () => {
+  test.each([
+    'domain_mismatch',
+    'target_url_mismatch',
+    'no_webhook_url',
+    'invalid_token',
+    'unknown',
+  ])('accepts %s', (reason) => {
+    const result = sendNotificationFailedTokenReasonSchema.safeParse(reason)
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects an unknown reason string', () => {
+    const result =
+      sendNotificationFailedTokenReasonSchema.safeParse('something_else')
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects a non-string', () => {
+    const result = sendNotificationFailedTokenReasonSchema.safeParse(42)
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('sendNotificationFailedTokenSchema', () => {
+  test('accepts a minimal entry', () => {
+    const result = sendNotificationFailedTokenSchema.safeParse({
+      token: 'abc',
+      reason: 'invalid_token',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts an entry with optional fid', () => {
+    const result = sendNotificationFailedTokenSchema.safeParse({
+      token: 'abc',
+      fid: 1234,
+      reason: 'domain_mismatch',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects a non-positive fid', () => {
+    const result = sendNotificationFailedTokenSchema.safeParse({
+      token: 'abc',
+      fid: 0,
+      reason: 'domain_mismatch',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects a missing reason', () => {
+    const result = sendNotificationFailedTokenSchema.safeParse({
+      token: 'abc',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects an invalid reason value', () => {
+    const result = sendNotificationFailedTokenSchema.safeParse({
+      token: 'abc',
+      reason: 'wat',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('sendNotificationResponseSchema', () => {
+  test('parses a legacy response without failedTokens', () => {
+    const result = sendNotificationResponseSchema.safeParse({
+      result: {
+        successfulTokens: ['t1', 't2'],
+        invalidTokens: ['t3'],
+        rateLimitedTokens: [],
+      },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.result.failedTokens).toBeUndefined()
+    }
+  })
+
+  test('parses a new response with failedTokens', () => {
+    const result = sendNotificationResponseSchema.safeParse({
+      result: {
+        successfulTokens: ['t1'],
+        invalidTokens: ['t2'],
+        rateLimitedTokens: [],
+        failedTokens: [
+          { token: 't2', fid: 42, reason: 'invalid_token' },
+          { token: 't3', fid: 99, reason: 'domain_mismatch' },
+          { token: 't4', reason: 'target_url_mismatch' },
+        ],
+      },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.result.failedTokens).toHaveLength(3)
+    }
+  })
+
+  test('rejects a response whose failedTokens has an invalid reason', () => {
+    const result = sendNotificationResponseSchema.safeParse({
+      result: {
+        successfulTokens: [],
+        invalidTokens: [],
+        rateLimitedTokens: [],
+        failedTokens: [{ token: 't1', reason: 'bogus' }],
+      },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects a response missing one of the legacy arrays', () => {
+    const result = sendNotificationResponseSchema.safeParse({
+      result: {
+        successfulTokens: [],
+        invalidTokens: [],
+      },
+    })
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds an optional `failedTokens` array to `sendNotificationResponseSchema.result`, letting notification servers report per-token failures with `fid` and `reason` instead of failing entire batches.
- New `sendNotificationFailedTokenReasonSchema` enum: `domain_mismatch`, `target_url_mismatch`, `no_webhook_url`, `invalid_token`, `unknown`.
- Adds Vitest coverage for the new schemas (legacy/new response shapes, valid/invalid reasons, optional fid).
- Additive and optional, so existing consumers (Zod strip mode) keep working unchanged.

## Reason values
| Reason | Meaning | Notes |
|---|---|---|
| `domain_mismatch` | Token's canonical domain doesn't match the targetUrl | Per-token failure within a mixed-domain batch; the rest of the batch still delivers |
| `target_url_mismatch` | The targetUrl matches none of the supplied tokens' domains | All tokens in the batch fail with this reason instead of throwing |
| `no_webhook_url` | The target domain has no manifest or no webhookUrl | Matching tokens fail with this reason instead of throwing |
| `invalid_token` | Mirror of an entry in the legacy `invalidTokens` array, with optional `fid` looked up from soft-deleted user_frames for richer reporting | **Additive**: tokens with this reason still appear in `invalidTokens` for backwards compatibility |
| `unknown` | Catch-all for forward compatibility | Reserved for future use |

## Relationship to `invalidTokens` (additive guarantee)
The new `failedTokens` array is fully additive — every token that the server would have placed in `invalidTokens` (or any other legacy array) is **still placed there**, AND **also mirrored into `failedTokens`** with a structured `reason` and an optional `fid`. New consumers can read `failedTokens` as the comprehensive view; old consumers continue reading `invalidTokens` and silently ignore the new field. This avoids any contradictory or duplicated reporting paths between the two — consumers that read both should dedupe by token.

## Context
This is part of a coordinated fix for NEYN-10064. We hit a production issue where the Farcaster notification API rejects entire 100-token batches with HTTP 400 + "All tokens must be for the same domain or its associated domains" if even one token in the batch is registered under a different mini-app domain. This silently broke notifications for all 100 users in each affected batch.

The new `failedTokens` field lets the backend surface per-token failures so the request can succeed for the well-behaved tokens while reporting the bad ones individually. The companion change in `merkle-team/backend` (separate PR) refactors `MiniAppService.sendNotification` to populate this field.

## Test plan
- [x] Schema parses an old response (no `failedTokens`)
- [x] Schema parses a new response (with `failedTokens`)
- [x] Schema rejects invalid reason strings (since `reason` is now an enum)
- [x] All 5 reason enum values are accepted
- [x] `fid` is optional but must be a positive int when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)