### PR TITLE
feat(core): launcher notification badge context (NEYN-10155)

### DIFF
--- a/.changeset/neyn-10155-badge-context.md
+++ b/.changeset/neyn-10155-badge-context.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/miniapp-core": patch
+---
+
+Add optional `notificationBadgeCount` and `notificationBadgesEnabled` on `ClientContext` so Farcaster clients can expose launcher / “Your Apps” notification badge state to Mini Apps.

--- a/packages/miniapp-core/src/context.ts
+++ b/packages/miniapp-core/src/context.ts
@@ -111,6 +111,18 @@ export type ClientContext = {
   clientFid: number
   added: boolean
   notificationDetails?: MiniAppNotificationDetails
+  /**
+   * When the Host surfaces a launcher or “Your Apps” style grid, this is the
+   * count of unread in-app notifications for this Mini App (e.g. for a red badge).
+   * Omitted when the Host does not track or expose a count.
+   */
+  notificationBadgeCount?: number
+  /**
+   * User preference in the Host: when `false`, notification badges should not be
+   * shown on this app’s icon (even if `notificationBadgeCount` is set).
+   * Omitted when the Host does not expose this setting.
+   */
+  notificationBadgesEnabled?: boolean
   safeAreaInsets?: SafeAreaInsets
 }
 

--- a/site/pages/docs/sdk/changelog.mdx
+++ b/site/pages/docs/sdk/changelog.mdx
@@ -5,6 +5,10 @@ description: Recent changes to the Mini Apps SDK
 
 # What's New
 
+## April 7, 2026
+
+- Optional `client.notificationBadgeCount` and `client.notificationBadgesEnabled` on [`context`](/docs/sdk/context) so Hosts can expose launcher / “Your Apps” notification badge counts and a user toggle to hide badges.
+
 ## December 19, 2024
 
 - Added experimental [`signManifest`](/docs/sdk/actions/sign-manifest) action for domain manifest verification:

--- a/site/pages/docs/sdk/context.mdx
+++ b/site/pages/docs/sdk/context.mdx
@@ -27,6 +27,10 @@ export type MiniAppContext = {
     added: boolean;
     safeAreaInsets?: SafeAreaInsets;
     notificationDetails?: MiniAppNotificationDetails;
+    /** Unread in-app notification count for launcher / “Your Apps” badges */
+    notificationBadgeCount?: number;
+    /** User toggle: when false, Host should not show notification badges for this app */
+    notificationBadgesEnabled?: boolean;
   };
   features?: {
     haptics: boolean;
@@ -294,6 +298,8 @@ Details about the Farcaster client running the Mini App. This should be consider
 - `added`: whether the user has added the Mini App to the client
 - `safeAreaInsets`: insets to avoid areas covered by navigation elements that obscure the view
 - `notificationDetails`: in case the user has enabled notifications, includes the `url` and `token` for sending notifications
+- `notificationBadgeCount` (optional): when the Host tracks unread in-app notifications for this Mini App, the count to display on the app icon in launcher or “Your Apps” style surfaces (e.g. a red badge). Omitted if the Host does not expose a count.
+- `notificationBadgesEnabled` (optional): user preference in the Host; when `false`, notification badges should not be shown for this app’s icon even if a count exists. Omitted if the Host does not expose this setting.
 
 ```ts
 export type SafeAreaInsets = {
@@ -308,6 +314,8 @@ export type ClientContext = {
   clientFid: number;
   added: boolean;
   notificationDetails?: MiniAppNotificationDetails;
+  notificationBadgeCount?: number;
+  notificationBadgesEnabled?: boolean;
   safeAreaInsets?: SafeAreaInsets;
 };
 ```
@@ -327,7 +335,9 @@ export type ClientContext = {
   notificationDetails: {
     url: "https://api.farcaster.xyz/v1/frame-notifications",
     token: "a05059ef2415c67b08ecceb539201cbc6"
-  }
+  },
+  notificationBadgeCount: 3,
+  notificationBadgesEnabled: true
 }
 ```
 
@@ -350,6 +360,8 @@ type ClientContext = {
   added: boolean;
   safeAreaInsets?: SafeAreaInsets;
   notificationDetails?: MiniAppNotificationDetails;
+  notificationBadgeCount?: number;
+  notificationBadgesEnabled?: boolean;
 };
 ```
 

--- a/site/pages/docs/specification.mdx
+++ b/site/pages/docs/specification.mdx
@@ -286,6 +286,24 @@ After a user adds a Mini App, the Host should make it easy to find and launch
 the Mini App by providing a top-level interface where users can browse and open
 added apps.
 
+#### Notification badges in launcher / Your Apps
+
+Hosts may show a small badge (for example a red dot with a numeric count) on a
+Mini App’s icon in launcher grids, “Your Apps”, or similar surfaces so users
+can see pending in-app notifications at a glance.
+
+When the Host tracks an unread count for the current Mini App session, it
+should pass it in `sdk.context.client.notificationBadgeCount` as a non-negative
+integer. When the count is zero or badges are turned off for this app (see
+below), the Host may omit `notificationBadgeCount` or set it to `0`.
+
+Hosts should offer a user-controlled setting to hide these notification badges
+(for example a toggle in app settings or in the Your Apps screen). When the
+user disables badges, the Host sets `sdk.context.client.notificationBadgesEnabled`
+to `false` for the Mini App context; when enabled or when the Host does not
+implement this preference, omit the field or set it to `true`. Mini Apps that
+read context can use `notificationBadgesEnabled === false` to avoid showing
+redundant in-app notification UI when the Host already hides badges.
 
 ### Server Events
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the SDK/spec side of [NEYN-10155](https://linear.app/): notification indicators for mini apps in launcher / “Your Apps” surfaces and a user-controlled way to hide badges.

This repository does not contain the Farcaster client UI; it defines the Mini App contract. Hosts (e.g. Warpcast) should:

- Show a numeric badge on app icons when `client.notificationBadgeCount` is a positive integer.
- Respect `client.notificationBadgesEnabled === false` so users can turn off badge noise.
- Omit these fields when not applicable.

## Changes

- **`ClientContext`**: optional `notificationBadgeCount` and `notificationBadgesEnabled` in `@farcaster/miniapp-core`.
- **Docs**: [Context](/docs/sdk/context), [specification](/docs/specification) (Host requirements), and [changelog](/docs/sdk/changelog).
- **Changeset**: patch bump for `@farcaster/miniapp-core`.

## Testing

- `pnpm --filter @farcaster/miniapp-core typecheck`
- `pnpm --filter @farcaster/miniapp-core test`
- `pnpm check`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NEYN-10155](https://linear.app/neynar/issue/NEYN-10155/mini-app-notification-badges-and-toggle-in-your-apps-view)

<div><a href="https://cursor.com/agents/bc-3e85c6a9-242f-48bd-b1b7-ac83a3cac6ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e85c6a9-242f-48bd-b1b7-ac83a3cac6ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

