### PR TITLE
fix(miniapp-sdk): reject token host actions when not in Mini App (NEYN-10173)

### DIFF
--- a/packages/miniapp-sdk/src/sdk.ts
+++ b/packages/miniapp-sdk/src/sdk.ts
@@ -55,6 +55,19 @@ async function isInMiniApp(timeoutMs = 1000): Promise<boolean> {
   return isInMiniApp
 }
 
+const NOT_IN_MINIAPP_ERROR =
+  'Not running inside a Mini App host (open this app from a supported Farcaster client).'
+
+/**
+ * Rejects immediately when the page is not embedded in a Mini App host, so host
+ * actions do not hang on Comlink calls that never get a response.
+ */
+async function ensureInMiniApp(): Promise<void> {
+  if (!(await isInMiniApp())) {
+    throw new Error(NOT_IN_MINIAPP_ERROR)
+  }
+}
+
 const addMiniApp = async () => {
   // Use the existing message overcomlink for backwards compat until
   // hosts are all upgraded.
@@ -115,9 +128,18 @@ export const sdk: MiniAppSDK = {
     composeCast(options = {}) {
       return miniAppHost.composeCast(options) as never
     },
-    viewToken: miniAppHost.viewToken.bind(miniAppHost),
-    sendToken: miniAppHost.sendToken.bind(miniAppHost),
-    swapToken: miniAppHost.swapToken.bind(miniAppHost),
+    viewToken: async (options) => {
+      await ensureInMiniApp()
+      return miniAppHost.viewToken(options)
+    },
+    sendToken: async (options) => {
+      await ensureInMiniApp()
+      return miniAppHost.sendToken(options)
+    },
+    swapToken: async (options) => {
+      await ensureInMiniApp()
+      return miniAppHost.swapToken(options)
+    },
     requestCameraAndMicrophoneAccess:
       miniAppHost.requestCameraAndMicrophoneAccess.bind(miniAppHost),
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In a standalone desktop browser tab (not embedded in a Mini App host), `viewToken`, `sendToken`, and `swapToken` routed Comlink calls to a window with no host listener, so promises never resolved and the kitchen sink buttons appeared to do nothing.

## Solution

- Added `ensureInMiniApp()` which throws with a clear message when `isInMiniApp()` is false.
- Wrapped `actions.viewToken`, `actions.sendToken`, and `actions.swapToken` to await `ensureInMiniApp()` before calling the host.

Callers now get an immediate rejection instead of a hanging promise.

## Notes

An optional endpoint-level short-circuit was considered but rejected: posting Comlink responses on the same `window` as `wrap()` would be picked up by the client’s message listener as bogus responses and could corrupt Comlink’s pending request map.

Fixes NEYN-10173.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NEYN-10173](https://linear.app/neynar/issue/NEYN-10173/snaps-kitchen-sink-demo-view-eth-send-eth-swap-eth-buttons-do-nothing)

<div><a href="https://cursor.com/agents/bc-2b20ba62-07c6-44ea-a5b3-9592a9de3067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b20ba62-07c6-44ea-a5b3-9592a9de3067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

