### PR TITLE
feat(miniapp-sdk): add addToSidebar action (alias for addMiniApp)

### DIFF
--- a/packages/miniapp-core/src/types.ts
+++ b/packages/miniapp-core/src/types.ts
@@ -54,6 +54,8 @@ export const miniAppHostCapabilityList = [
   'actions.close',
   'actions.setPrimaryButton',
   'actions.addMiniApp',
+  /** Alias for `actions.addMiniApp` (prompt to add the app to the client sidebar / apps list). */
+  'actions.addToSidebar',
   'actions.signIn',
   'actions.viewCast',
   'actions.viewProfile',

--- a/packages/miniapp-sdk/src/sdk.ts
+++ b/packages/miniapp-sdk/src/sdk.ts
@@ -1,6 +1,7 @@
 import {
   AddMiniApp,
   type MiniAppClientEvent,
+  type MiniAppHostCapability,
   SignIn,
   SignManifest,
 } from '@farcaster/miniapp-core'
@@ -13,6 +14,17 @@ import { getSolanaProvider } from './solanaProvider.ts'
 import type { MiniAppSDK } from './types.ts'
 
 let cachedIsInMiniAppResult: boolean | null = null
+
+async function getCapabilities(): Promise<MiniAppHostCapability[]> {
+  const caps = await miniAppHost.getCapabilities()
+  if (
+    caps.includes('actions.addMiniApp') &&
+    !caps.includes('actions.addToSidebar')
+  ) {
+    return [...caps, 'actions.addToSidebar']
+  }
+  return caps
+}
 
 /**
  * Determines if the current environment is a MiniApp context.
@@ -76,7 +88,7 @@ const addMiniApp = async () => {
 
 export const sdk: MiniAppSDK = {
   ...emitter,
-  getCapabilities: miniAppHost.getCapabilities,
+  getCapabilities,
   getChains: miniAppHost.getChains,
   isInMiniApp,
   context: miniAppHost.context,
@@ -112,6 +124,7 @@ export const sdk: MiniAppSDK = {
     },
     addFrame: addMiniApp,
     addMiniApp,
+    addToSidebar: addMiniApp,
     composeCast(options = {}) {
       return miniAppHost.composeCast(options) as never
     },

--- a/packages/miniapp-sdk/src/types.ts
+++ b/packages/miniapp-sdk/src/types.ts
@@ -80,6 +80,8 @@ export type MiniAppSDK = {
     // Deprecated in favor of addMiniApp
     addFrame: AddMiniApp.AddMiniApp
     addMiniApp: AddMiniApp.AddMiniApp
+    /** Same as `addMiniApp` — prompts the user to add this app to the client sidebar (apps list). */
+    addToSidebar: AddMiniApp.AddMiniApp
     signIn: SignIn.SignIn
     viewCast: ViewCast.ViewCast
     viewProfile: ViewProfile.ViewProfile

--- a/site/pages/docs/sdk/actions/add-miniapp.mdx
+++ b/site/pages/docs/sdk/actions/add-miniapp.mdx
@@ -9,6 +9,8 @@ import { Caption } from '../../../../components/Caption.tsx';
 
 Prompts the user to add the app.
 
+`sdk.actions.addToSidebar()` is an alias for the same behavior—use whichever name fits your UI copy (for example “Add to sidebar” in clients that surface saved apps there).
+
 ![adding a mini app in Warpcast](/add_frame_preview.png)
 
 <Caption>

--- a/site/pages/docs/sdk/actions/add-to-sidebar.mdx
+++ b/site/pages/docs/sdk/actions/add-to-sidebar.mdx
@@ -1,0 +1,18 @@
+---
+title: addToSidebar
+description: Prompts the user to add the app (same as addMiniApp)
+---
+
+# addToSidebar
+
+Alias for [addMiniApp](/docs/sdk/actions/add-miniapp): prompts the user to add this Mini App so it appears in the client’s apps list (often shown in a sidebar).
+
+## Usage
+
+```ts twoslash
+import { sdk } from '@farcaster/miniapp-sdk'
+
+await sdk.actions.addToSidebar()
+```
+
+See [addMiniApp](/docs/sdk/actions/add-miniapp) for requirements, return value, and errors.

--- a/site/pages/docs/specification.mdx
+++ b/site/pages/docs/specification.mdx
@@ -135,6 +135,7 @@ is maintained within the code base to document all changes.
 
 #### Actions
 - [addMiniApp](/docs/sdk/actions/add-miniapp) - Prompts the user to add the Mini App
+- [addToSidebar](/docs/sdk/actions/add-to-sidebar) - Same as addMiniApp (alias for “add to sidebar” UX)
 - [close](/docs/sdk/actions/close) - Closes the Mini App
 - [composeCast](/docs/sdk/actions/compose-cast) - Prompt the user to cast
 - [ready](/docs/sdk/actions/ready) - Hides the Splash Screen

--- a/site/vocs.config.tsx
+++ b/site/vocs.config.tsx
@@ -181,6 +181,10 @@ export default defineConfig({
                 link: '/docs/sdk/actions/add-miniapp',
               },
               {
+                text: 'addToSidebar',
+                link: '/docs/sdk/actions/add-to-sidebar',
+              },
+              {
                 text: 'close',
                 link: '/docs/sdk/actions/close',
               },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements NEYN-10365 by exposing **`sdk.actions.addToSidebar()`** as an alias for the existing “add this Mini App” flow (`addMiniApp` / legacy `addFrame`). No new host RPC is required.

## Changes

- **`sdk.actions.addToSidebar`** — same implementation and errors as `addMiniApp`.
- **`actions.addToSidebar`** added to `miniAppHostCapabilityList` in `@farcaster/miniapp-core` so manifests can declare `requiredCapabilities` with this name.
- **`sdk.getCapabilities()`** — when the host returns `actions.addMiniApp` but not `actions.addToSidebar`, the SDK appends `actions.addToSidebar` so capability checks stay consistent.
- **Docs** — new action page, spec entry, sidebar link, and a short note on the `addMiniApp` page.

## Testing

- `pnpm typecheck --filter=@farcaster/miniapp-sdk --filter=@farcaster/miniapp-core`
- `pnpm check` (Biome) ran on commit
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NEYN-10365](https://linear.app/neynar/issue/NEYN-10365/sdk-feature-request-add-to-sidebar-action)

<div><a href="https://cursor.com/agents/bc-57a4a7c5-73f7-498d-b460-67a6957847f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57a4a7c5-73f7-498d-b460-67a6957847f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

