### PR TITLE
fix(NEYN-10434): backward-compat openSnap → openMiniApp in host/SDK

### DIFF
--- a/packages/miniapp-core/src/types.ts
+++ b/packages/miniapp-core/src/types.ts
@@ -62,6 +62,8 @@ export const miniAppHostCapabilityList = [
   'actions.sendToken',
   'actions.swapToken',
   'actions.openMiniApp',
+  // Legacy alias for actions.openMiniApp (Frames `open_snap`)
+  'actions.openSnap',
   'actions.requestCameraAndMicrophoneAccess',
   'experimental.signManifest',
   'haptics.impactOccurred',
@@ -97,6 +99,8 @@ export type WireMiniAppHost = {
   sendToken: SendToken.SendToken
   swapToken: SwapToken.SwapToken
   openMiniApp: OpenMiniApp.OpenMiniApp
+  /** @deprecated Legacy Frames wire name; same as {@link openMiniApp}. */
+  openSnap: OpenMiniApp.OpenMiniApp
   composeCast: <close extends boolean | undefined = undefined>(
     options: ComposeCast.Options<close>,
   ) => Promise<ComposeCast.Result<close>>

--- a/packages/miniapp-host/src/comlink/comlink.ts
+++ b/packages/miniapp-host/src/comlink/comlink.ts
@@ -387,6 +387,9 @@ export function expose(
                 return obj.updateBackState(...argumentList);
               case 'openMiniApp':
                 return obj.openMiniApp(...argumentList);
+              // Legacy Frames SDK name for opening another mini app
+              case 'openSnap':
+                return obj.openSnap(...argumentList);
               default:
                 throw new Error(`Unsupported APPLY for ${path.join('/')}`)
             }

--- a/packages/miniapp-host/src/helpers/sdk.ts
+++ b/packages/miniapp-host/src/helpers/sdk.ts
@@ -9,6 +9,7 @@ import {
 export function wrapHandlers(host: MiniAppHost): WireMiniAppHost {
   return {
     ...host,
+    openSnap: host.openMiniApp,
     addFrame: async () => {
       try {
         const result = await host.addMiniApp()

--- a/packages/miniapp-sdk/src/sdk.ts
+++ b/packages/miniapp-sdk/src/sdk.ts
@@ -91,6 +91,7 @@ export const sdk: MiniAppSDK = {
     viewCast: miniAppHost.viewCast.bind(miniAppHost),
     viewProfile: miniAppHost.viewProfile.bind(miniAppHost),
     openMiniApp: miniAppHost.openMiniApp.bind(miniAppHost),
+    openSnap: miniAppHost.openSnap.bind(miniAppHost),
     signIn: async (options) => {
       const response = await miniAppHost.signIn({
         ...options,

--- a/packages/miniapp-sdk/src/types.ts
+++ b/packages/miniapp-sdk/src/types.ts
@@ -90,6 +90,8 @@ export type MiniAppSDK = {
     sendToken: SendToken.SendToken
     swapToken: SwapToken.SwapToken
     openMiniApp: OpenMiniApp.OpenMiniApp
+    /** @deprecated Legacy Frames action name; same as {@link openMiniApp}. */
+    openSnap: OpenMiniApp.OpenMiniApp
     requestCameraAndMicrophoneAccess: RequestCameraAndMicrophoneAccess.RequestCameraAndMicrophoneAccess
   }
   experimental: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **NEYN-10434**: legacy Frames **`open_snap`** actions (wired over Comlink as **`openSnap`**) were rejected by the mini app host because only **`openMiniApp`** was handled, so clicks did nothing.

## Changes

- **`packages/miniapp-host/src/comlink/comlink.ts`**: handle **`openSnap`** APPLY messages by delegating to the same implementation as **`openMiniApp`**.
- **`packages/miniapp-host/src/helpers/sdk.ts`**: expose **`openSnap`** on the wire host as an alias of **`openMiniApp`**.
- **`packages/miniapp-sdk/src/sdk.ts`** / **`types.ts`**: add **`actions.openSnap`** as an alias of **`openMiniApp`** for explicit SDK use.
- **`packages/miniapp-core/src/types.ts`**: extend **`WireMiniAppHost`** with **`openSnap`** and add **`actions.openSnap`** to **`miniAppHostCapabilityList`** so manifests can require the legacy capability path.

## Testing

- `pnpm --filter @farcaster/miniapp-core build`
- `pnpm --filter @farcaster/miniapp-host --filter @farcaster/miniapp-sdk typecheck`
- `pnpm --filter @farcaster/miniapp-core test`
- `pnpm biome check` on touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NEYN-10434](https://linear.app/neynar/issue/NEYN-10434/open-snap-action-more-airdrops-does-nothing-on-schnapps-airdrop-snap)

<div><a href="https://cursor.com/agents/bc-9d3c5760-4a59-4fbf-8572-1aa35a41abae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d3c5760-4a59-4fbf-8572-1aa35a41abae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

