### PR TITLE
fix(miniapp-core): usernameSchema for ENS-style Farcaster names (NEYN-10523)

### DIFF
--- a/packages/miniapp-core/src/schemas/shared.ts
+++ b/packages/miniapp-core/src/schemas/shared.ts
@@ -118,6 +118,27 @@ export const domainSchema = z
     message: 'Domain must not include port numbers',
   })
 
+// Farcaster fName (no dots): lowercase letters, digits, underscore.
+// ENS-style names (e.g. *.eth, *.base.eth): validated like domain labels via DOMAIN_REGEX.
+const FNAME_USERNAME_REGEX = /^[a-z0-9_]{1,64}$/
+
+export const usernameSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .refine(
+    (value) =>
+      value.includes('.')
+        ? DOMAIN_REGEX.test(value)
+        : FNAME_USERNAME_REGEX.test(value),
+    {
+      message:
+        'Must be a valid Farcaster username (fName) or ENS-style name (e.g. name.eth, name.base.eth)',
+    },
+  )
+
+export type UsernameSchema = z.infer<typeof usernameSchema>
+
 export const aspectRatioSchema = z.union([z.literal('1:1'), z.literal('3:2')])
 
 export const encodedJsonFarcasterSignatureSchema = z.object({

--- a/packages/miniapp-core/tests/schemas/shared.test.ts
+++ b/packages/miniapp-core/tests/schemas/shared.test.ts
@@ -3,6 +3,7 @@ import {
   createSimpleStringSchema,
   domainSchema,
   secureUrlSchema,
+  usernameSchema,
 } from '../../src/schemas/shared.ts'
 
 describe('createSimpleStringSchema', () => {
@@ -106,6 +107,48 @@ describe('domainSchema', () => {
     for (const domain of invalidDomains) {
       const result = domainSchema.safeParse(domain)
       expect(result.success, `Expected invalid domain: ${domain}`).toBe(false)
+    }
+  })
+})
+
+describe('usernameSchema', () => {
+  test('accepts fName-style usernames', () => {
+    const valid = ['six', 'alphacaster', 'user_123', 'a']
+
+    for (const username of valid) {
+      const result = usernameSchema.safeParse(username)
+      expect(result.success, `Expected valid username: ${username}`).toBe(true)
+    }
+  })
+
+  test('accepts ENS-style usernames with dots', () => {
+    const valid = [
+      'alphacaster.eth',
+      'alphacaster.base.eth',
+      'sub.alphacaster.base.eth',
+    ]
+
+    for (const username of valid) {
+      const result = usernameSchema.safeParse(username)
+      expect(result.success, `Expected valid username: ${username}`).toBe(true)
+    }
+  })
+
+  test('rejects invalid usernames', () => {
+    const invalid = [
+      '', // empty
+      'Alphacaster', // uppercase in fName segment
+      'alpha-caster', // hyphen only allowed in dotted ENS-style names
+      'alphacaster..eth', // consecutive dots
+      'alphacaster@eth', // invalid character
+      'a.b', // TLD too short
+    ]
+
+    for (const username of invalid) {
+      const result = usernameSchema.safeParse(username)
+      expect(result.success, `Expected invalid username: ${username}`).toBe(
+        false,
+      )
     }
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `usernameSchema` in `@farcaster/miniapp-core` so sign-in and other flows can validate Farcaster identities that use ENS-style names with dots (for example `*.eth` and `*.base.eth`), not only fName-style identifiers.

## Details

- **Dotted names** reuse the same `DOMAIN_REGEX` rules as `domainSchema`, so labels follow normal domain constraints (no `..`, valid TLD length, etc.).
- **Dotless names** keep the usual fName pattern: lowercase letters, digits, and underscore, max 64 characters.

## Tests

- Vitest coverage for fName, `alphacaster.eth`, `alphacaster.base.eth`, and invalid cases.

Linear: NEYN-10523
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NEYN-10523](https://linear.app/neynar/issue/NEYN-10523/clankerworld-desktop-signin-fails-after-qr-approval-when-farcaster)

<div><a href="https://cursor.com/agents/bc-287d487d-3082-44ec-beb5-ac5ab13d792a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-287d487d-3082-44ec-beb5-ac5ab13d792a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

