### PR TITLE
fix: isolate mini app scroll in browser iframes

### DIFF
--- a/.changeset/miniapp-browser-scroll.md
+++ b/.changeset/miniapp-browser-scroll.md
@@ -1,0 +1,6 @@
+---
+'@farcaster/miniapp-sdk': patch
+'@farcaster/miniapp-host': patch
+---
+
+Isolate mini app document scrolling in browser iframes: set `overscroll-behavior` on the root document, and default iframe sizing so the embedded app can fill its viewport without fighting the parent page scroll.

--- a/packages/miniapp-host/src/iframe.ts
+++ b/packages/miniapp-host/src/iframe.ts
@@ -60,18 +60,37 @@ export function exposeToIframe({
   ethProvider?: OxProvider.Provider<undefined, true>
   debug?: boolean
 }) {
+  const prevInline = {
+    width: iframe.style.width,
+    height: iframe.style.height,
+    minHeight: iframe.style.minHeight,
+    display: iframe.style.display,
+  }
+  if (!prevInline.width) iframe.style.width = '100%'
+  if (!prevInline.height) iframe.style.height = '100%'
+  if (!prevInline.minHeight) iframe.style.minHeight = '100%'
+  if (!prevInline.display) iframe.style.display = 'block'
+
   const endpoint = createIframeEndpoint({
     iframe,
     targetOrigin: miniAppOrigin,
     debug,
   })
-  const cleanup = exposeToEndpoint({
+  const cleanupRpc = exposeToEndpoint({
     endpoint,
     sdk,
     ethProvider,
     miniAppOrigin,
     debug,
   })
+
+  const cleanup = () => {
+    cleanupRpc()
+    iframe.style.width = prevInline.width
+    iframe.style.height = prevInline.height
+    iframe.style.minHeight = prevInline.minHeight
+    iframe.style.display = prevInline.display
+  }
 
   return {
     endpoint,

--- a/packages/miniapp-sdk/src/sdk.ts
+++ b/packages/miniapp-sdk/src/sdk.ts
@@ -189,6 +189,21 @@ if (typeof document !== 'undefined') {
 }
 
 // Required to pass SSR
+if (
+  typeof window !== 'undefined' &&
+  typeof document !== 'undefined' &&
+  window !== window.parent
+) {
+  // Prevent scroll chaining to the parent host page when the mini app runs in
+  // an iframe in the browser (nested scroll / rubber-band conflicts).
+  for (const el of [document.documentElement, document.body]) {
+    el.style.setProperty('overscroll-behavior', 'contain')
+    el.style.setProperty('overscroll-behavior-y', 'contain')
+    el.style.setProperty('min-height', '100%')
+  }
+}
+
+// Required to pass SSR
 if (typeof window !== 'undefined') {
   // web events
   window.addEventListener('message', (event) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces nested scroll conflicts when mini apps run in a browser iframe by stopping scroll chaining at the embedded document and giving iframes sensible default dimensions when hosts omit them.

## Changes

- **`@farcaster/miniapp-sdk`**: When the app loads in an iframe (`window !== window.parent`), set `overscroll-behavior` / `overscroll-behavior-y` to `contain` and `min-height: 100%` on `document.documentElement` and `document.body` so scroll and overscroll do not chain to the parent page.
- **`@farcaster/miniapp-host`**: In `exposeToIframe`, when the iframe has no inline `width` / `height` / `minHeight` / `display`, default to `width: 100%`, `height: 100%`, `min-height: 100%`, and `display: block` so the embedded document can fill the host scrollport; restore previous inline styles on cleanup.

## Testing

- `pnpm exec biome check` on touched files
- `pnpm --filter @farcaster/miniapp-core build && pnpm --filter @farcaster/miniapp-sdk typecheck && pnpm --filter @farcaster/miniapp-host typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NEYN-10639](https://linear.app/neynar/issue/NEYN-10639/mini-apps-in-browser-need-independent-scroll-bar-to-avoid-nested)

<div><a href="https://cursor.com/agents/bc-7d0fc9f6-486a-459a-af32-d52fcd78cca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d0fc9f6-486a-459a-af32-d52fcd78cca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

