### PR TITLE
docs: warn that www. prefix creates a separate app [NEYN-10656]

### DIFF
--- a/site/pages/docs/guides/domain-migration.mdx
+++ b/site/pages/docs/guides/domain-migration.mdx
@@ -160,6 +160,14 @@ Ensure that:
 
 This is normal during transition. Some clients may cache manifest data, and users may have bookmarked the old URL. Continue to serve redirects from the old domain.
 
+### `www.` prefix issues
+
+The `www.` prefix is treated as a subdomain. `www.example.com` and `example.com`
+are different domains and will be treated as separate apps. If your app is on
+`example.com`, do not use `www.example.com` as either a `canonicalDomain` value
+or in your `targetUrl` when sending notifications — this will cause domain
+mismatch errors and token invalidation.
+
 ### Account association issues
 
 Make sure you use the same account to produce the association on both domains to maintain ownership verification. Do not reuse the account association data from one manifest to the other.

--- a/site/pages/docs/guides/domain-migration.mdx
+++ b/site/pages/docs/guides/domain-migration.mdx
@@ -27,7 +27,7 @@ This ensures continuity for your users and preserves your app's presence in app 
 
 ### Prepare your new domain
 
-Set up your Mini App on the new domain with a complete manifest file at `/.well-known/farcaster.json`. This should include all your app configuration and an account association from the same FID to maintain ownership verification.
+Set up your Mini App on the new domain with a complete manifest file at `/.well-known/farcaster.json`. This should include all your app configuration, an account association from the same FID, and a `canonicalDomain` field pointing to itself (the new domain).
 
 :::warning
 Keep the same `webhookUrl` in your new domain's manifest. If you use a managed
@@ -49,6 +49,7 @@ notifications for existing users.
     "name": "Your App Name",
     "iconUrl": "https://new-domain.com/icon.png",
     "homeUrl": "https://new-domain.com",
+    "canonicalDomain": "new-domain.com",
     // ... other configuration
   }
 }
@@ -70,11 +71,19 @@ Add the `canonicalDomain` field to your manifest on the **old domain**, pointing
     "name": "Your App Name",
     "iconUrl": "https://old-domain.com/icon.png",
     "homeUrl": "https://old-domain.com",
-    "canonicalDomain": "new-domain.com", // Add this line
+    "canonicalDomain": "new-domain.com",
     // ... other configuration
   }
 }
 ```
+
+:::warning
+Both manifests must be live simultaneously and both must set `canonicalDomain`
+to the same value (the new domain). Farcaster verifies the `canonicalDomain`
+by fetching the manifest from the target domain — if the new domain's manifest
+is missing or doesn't include a matching `canonicalDomain`, the migration will
+not be processed.
+:::
 
 :::note
 The `canonicalDomain` value must be a valid domain name without protocol, port, or path:
@@ -84,28 +93,6 @@ The `canonicalDomain` value must be a valid domain name without protocol, port, 
 - ❌ `new-domain.com:3000`
 - ❌ `new-domain.com/app`
 :::
-
-### Optional: Add canonicalDomain to the new manifest
-
-You can optionally include the `canonicalDomain` field in your new domain's manifest as well, pointing to itself. This can help with client caching and ensures consistency:
-
-```json
-{
-  "accountAssociation": {
-    "header": "...",
-    "payload": "...",
-    "signature": "..."
-  },
-  "miniapp": {
-    "version": "1",
-    "name": "Your App Name",
-    "iconUrl": "https://new-domain.com/icon.png",
-    "homeUrl": "https://new-domain.com",
-    "canonicalDomain": "new-domain.com", // Self-referential
-    // ... other configuration
-  }
-}
-```
 
 ### Maintain both domains during transition
 

--- a/site/pages/docs/guides/domain-migration.mdx
+++ b/site/pages/docs/guides/domain-migration.mdx
@@ -87,7 +87,7 @@ The `canonicalDomain` value must be a valid domain name without protocol, port, 
 
 ### Add canonicalDomain to the new manifest
 
-Add the same `canonicalDomain` field to your **new domain's** manifest, pointing to itself:
+Include the `canonicalDomain` field in your new domain's manifest as well, pointing to itself. This ensures consistency and makes it clear which domain is canonical:
 
 ```json
 {
@@ -108,11 +108,9 @@ Add the same `canonicalDomain` field to your **new domain's** manifest, pointing
 ```
 
 :::warning
-Both manifests must be live simultaneously and both must set `canonicalDomain`
-to the same value (the new domain). Farcaster verifies the `canonicalDomain`
-by fetching the manifest from the target domain — if the new domain's manifest
-is missing or doesn't include a matching `canonicalDomain`, the migration will
-not be processed.
+Both manifests must be live simultaneously. Farcaster verifies the
+`canonicalDomain` by fetching the manifest from the target domain — if the new
+domain's manifest is not accessible, the migration will not be processed.
 :::
 
 ### Maintain both domains during transition

--- a/site/pages/docs/guides/domain-migration.mdx
+++ b/site/pages/docs/guides/domain-migration.mdx
@@ -29,6 +29,14 @@ This ensures continuity for your users and preserves your app's presence in app 
 
 Set up your Mini App on the new domain with a complete manifest file at `/.well-known/farcaster.json`. This should include all your app configuration and an account association from the same FID to maintain ownership verification.
 
+:::warning
+Keep the same `webhookUrl` in your new domain's manifest. If you use a managed
+notification service like [Neynar](https://neynar.com), this means using the
+same Neynar app — do not create a new one. Changing the `webhookUrl` will cause
+new notification tokens to be stored separately from the migrated ones, breaking
+notifications for existing users.
+:::
+
 ```json
 {
   "accountAssociation": {

--- a/site/pages/docs/guides/domain-migration.mdx
+++ b/site/pages/docs/guides/domain-migration.mdx
@@ -101,7 +101,7 @@ Include the `canonicalDomain` field in your new domain's manifest as well, point
     "name": "Your App Name",
     "iconUrl": "https://new-domain.com/icon.png",
     "homeUrl": "https://new-domain.com",
-    "canonicalDomain": "new-domain.com",
+    "canonicalDomain": "new-domain.com", // Self-referential
     // ... other configuration
   }
 }

--- a/site/pages/docs/guides/domain-migration.mdx
+++ b/site/pages/docs/guides/domain-migration.mdx
@@ -70,7 +70,7 @@ Add the `canonicalDomain` field to your manifest on the **old domain**, pointing
     "name": "Your App Name",
     "iconUrl": "https://old-domain.com/icon.png",
     "homeUrl": "https://old-domain.com",
-    "canonicalDomain": "new-domain.com",
+    "canonicalDomain": "new-domain.com", // Add this line
     // ... other configuration
   }
 }

--- a/site/pages/docs/guides/domain-migration.mdx
+++ b/site/pages/docs/guides/domain-migration.mdx
@@ -27,7 +27,7 @@ This ensures continuity for your users and preserves your app's presence in app 
 
 ### Prepare your new domain
 
-Set up your Mini App on the new domain with a complete manifest file at `/.well-known/farcaster.json`. This should include all your app configuration, an account association from the same FID, and a `canonicalDomain` field pointing to itself (the new domain).
+Set up your Mini App on the new domain with a complete manifest file at `/.well-known/farcaster.json`. This should include all your app configuration and an account association from the same FID to maintain ownership verification.
 
 :::warning
 Keep the same `webhookUrl` in your new domain's manifest. If you use a managed
@@ -49,7 +49,6 @@ notifications for existing users.
     "name": "Your App Name",
     "iconUrl": "https://new-domain.com/icon.png",
     "homeUrl": "https://new-domain.com",
-    "canonicalDomain": "new-domain.com",
     // ... other configuration
   }
 }
@@ -77,14 +76,6 @@ Add the `canonicalDomain` field to your manifest on the **old domain**, pointing
 }
 ```
 
-:::warning
-Both manifests must be live simultaneously and both must set `canonicalDomain`
-to the same value (the new domain). Farcaster verifies the `canonicalDomain`
-by fetching the manifest from the target domain — if the new domain's manifest
-is missing or doesn't include a matching `canonicalDomain`, the migration will
-not be processed.
-:::
-
 :::note
 The `canonicalDomain` value must be a valid domain name without protocol, port, or path:
 - ✅ `app.new-domain.com`
@@ -92,6 +83,36 @@ The `canonicalDomain` value must be a valid domain name without protocol, port, 
 - ❌ `https://new-domain.com`
 - ❌ `new-domain.com:3000`
 - ❌ `new-domain.com/app`
+:::
+
+### Add canonicalDomain to the new manifest
+
+Add the same `canonicalDomain` field to your **new domain's** manifest, pointing to itself:
+
+```json
+{
+  "accountAssociation": {
+    "header": "...",
+    "payload": "...",
+    "signature": "..."
+  },
+  "miniapp": {
+    "version": "1",
+    "name": "Your App Name",
+    "iconUrl": "https://new-domain.com/icon.png",
+    "homeUrl": "https://new-domain.com",
+    "canonicalDomain": "new-domain.com",
+    // ... other configuration
+  }
+}
+```
+
+:::warning
+Both manifests must be live simultaneously and both must set `canonicalDomain`
+to the same value (the new domain). Farcaster verifies the `canonicalDomain`
+by fetching the manifest from the target domain — if the new domain's manifest
+is missing or doesn't include a matching `canonicalDomain`, the migration will
+not be processed.
 :::
 
 ### Maintain both domains during transition

--- a/site/pages/docs/guides/notifications.mdx
+++ b/site/pages/docs/guides/notifications.mdx
@@ -136,6 +136,13 @@ import SendNotificationRequestSchema from '../../../snippets/sendNotificationReq
 
 <SendNotificationRequestSchema />
 
+:::warning
+The `targetUrl` hostname must exactly match the domain your Mini App is registered
+on. Subdomains matter: if your app is on `example.com`, using
+`www.example.com` in the `targetUrl` will cause a `target_url_mismatch` error
+and the affected tokens will be permanently invalidated.
+:::
+
 The server should response with an HTTP 200 OK and the following JSON body:
 
 import SendNotificationResponseSchema from '../../../snippets/sendNotificationResponseSchema.mdx'

--- a/site/pages/docs/guides/publishing.mdx
+++ b/site/pages/docs/guides/publishing.mdx
@@ -41,6 +41,13 @@ include a subdomain.
 - ❌ https://rewards.warpcast.com
 :::
 
+:::warning
+The `www.` prefix is treated as a subdomain like any other. `www.example.com`
+and `example.com` are considered **different apps** with separate notification
+tokens and user data. Pick one and use it consistently everywhere — in your
+manifest, `accountAssociation`, and `targetUrl` when sending notifications.
+:::
+
 
 ### Host a manifest file
 


### PR DESCRIPTION
## Summary
- Adds warnings to publishing, notifications, and domain migration guides that `www.example.com` and `example.com` are treated as **different apps** with separate tokens/user data
- Clarifies that `targetUrl` in notification requests must use the exact registered domain — mismatches cause `target_url_mismatch` errors and permanent token invalidation
- Motivated by a real incident where a developer's app inconsistently used `www.` prefix, causing mass invalidation of ~6,700 notification tokens

## Test plan
- [ ] Verify docs build without errors
- [ ] Review warning callouts render correctly on publishing, notifications, and domain migration pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)