### PR TITLE
Add optional swapToken display hints for prominent token cost in host UI

### DIFF
--- a/.changeset/swap-token-display-hints.md
+++ b/.changeset/swap-token-display-hints.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/miniapp-core": patch
+---
+
+Add optional `display` field on `swapToken` options (`headline`, `subline`) so mini apps can suggest prominent cost copy for host swap UIs.

--- a/packages/miniapp-core/src/actions/SwapToken.ts
+++ b/packages/miniapp-core/src/actions/SwapToken.ts
@@ -1,3 +1,18 @@
+/**
+ * Optional copy for the host swap UI so users can see cost and outcome
+ * before confirming (e.g. a prominent headline for required token amount).
+ */
+export type SwapTokenDisplayHints = {
+  /**
+   * Short primary line shown prominently in the swap sheet (e.g. "5,000,000 tokens").
+   */
+  headline?: string
+  /**
+   * Supporting line (e.g. "You receive 1 entry" or token names).
+   */
+  subline?: string
+}
+
 export type SwapTokenOptions = {
   /**
    * CAIP-19 asset ID
@@ -17,6 +32,12 @@ export type SwapTokenOptions = {
    * For example, 1 USDC: 1000000
    */
   sellAmount?: string
+
+  /**
+   * Human-readable hints for the host to surface in the swap UI alongside
+   * chain amounts. Hosts may ignore unsupported fields.
+   */
+  display?: SwapTokenDisplayHints
 }
 
 type SwapTokenDetails = {

--- a/site/pages/docs/sdk/actions/swap-token.mdx
+++ b/site/pages/docs/sdk/actions/swap-token.mdx
@@ -22,6 +22,10 @@ await sdk.actions.swapToken({
   sellToken,
   buyToken,
   sellAmount,
+  display: {
+    headline: "5,000,000 tokens",
+    subline: "Required to participate",
+  },
 })
 ```
 
@@ -53,10 +57,21 @@ Sell token amount, as numeric string
 
 For example, 1 USDC: 1000000
 
+### display (optional)
+
+- **Type:** `{ headline?: string; subline?: string }`
+
+Optional copy for the **host** swap UI so required amounts and outcomes are easy to see before the user confirms. `headline` is intended for a prominent primary line (for example formatted token totals); `subline` can explain what the swap is for. Farcaster clients that support this field show it in the swap sheet; others ignore it. Numeric `sellAmount` remains the source of truth for the transaction.
+
 
 ## Return Value
 
 ```ts twoslash
+type SwapTokenDisplayHints = {
+  headline?: string;
+  subline?: string;
+};
+
 type SwapTokenDetails = {
   /**
    * Array of tx identifiers in order of execution.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

User feedback (NEYN-10665) asked for a more prominent display of token cost during mini app swap flows (e.g. word-a-day requiring 5,000,000 tokens). This repository defines the mini app SDK contract; the Farcaster client renders the swap sheet.

## Changes

- Extended `SwapTokenOptions` in `@farcaster/miniapp-core` with optional `display?: { headline?: string; subline?: string }` so mini apps can pass human-readable copy the host can show prominently (formatted totals, “required to participate”, etc.). `sellAmount` remains the source of truth for the transaction.
- Documented the field and usage example on the [swapToken](https://farcaster.xyz/miniapps/docs/sdk/actions/swap-token) docs page.

## Follow-up (outside this repo)

Host / miniapp-host client implementations should read `display.headline` and `display.subline` when present and render them prominently in the swap confirmation UI. The word-a-day app should pass e.g. `display: { headline: "5,000,000 tokens", subline: "Required to participate" }` alongside `sellAmount`.

## Testing

- `pnpm --filter @farcaster/miniapp-core typecheck`
- `pnpm check`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NEYN-10665](https://linear.app/neynar/issue/NEYN-10665/make-token-cost-clearer-in-word-a-day-app-swap-flow-display-5000000)

<div><a href="https://cursor.com/agents/bc-0195f2c3-afbb-4cbd-914c-478b4bdf46ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0195f2c3-afbb-4cbd-914c-478b4bdf46ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

