### PR TITLE
docs: query params are forwarded to a declared action.url (NEYN-12877)

### DIFF
--- a/site/pages/docs/guides/sharing.mdx
+++ b/site/pages/docs/guides/sharing.mdx
@@ -86,6 +86,8 @@ The string literal `'launch_miniapp'` (or `'launch_frame'` for backward compatib
 
 The URL that the user will be sent to within your app. If not provided, it defaults to the current webpage URL (including query parameters).
 
+When it _is_ provided, query parameters from the URL the user actually opened (for example a cast embed with `?ref=…`) are merged onto your declared `action.url` so your app still receives them. If the same parameter appears in both, the value declared in your `action.url` wins.
+
 
 ### `button.action.name` (optional)
 

--- a/site/pages/docs/sdk/actions/open-miniapp.mdx
+++ b/site/pages/docs/sdk/actions/open-miniapp.mdx
@@ -44,6 +44,14 @@ type OpenMiniAppOptions = {
   - A Mini App embed URL (e.g., `https://example.com/specific-page`)
   - A Mini App launch URL (e.g., `https://farcaster.xyz/miniapps/[id]/[name]`)
 
+:::note
+Query params on `url` are forwarded to the target Mini App even when it declares
+its own `action.url` — they are merged onto the resolved launch URL so the
+target can read them from `window.location.search`. If the same param is
+declared in both, the target's `action.url` value wins. This is what makes the
+referral example below (`searchParams.get('ref')`) work.
+:::
+
 ## Return Value
 
 `Promise<void>` - The promise resolves when navigation is successful. If navigation fails, the promise will be rejected with an error.

--- a/site/pages/docs/sdk/changelog.mdx
+++ b/site/pages/docs/sdk/changelog.mdx
@@ -5,6 +5,10 @@ description: Recent changes to the Mini Apps SDK
 
 # What's New
 
+## July 30, 2026
+
+- Query parameters are now forwarded to a Mini App even when it declares its own `button.action.url`. When a Mini App is launched from a link (for example a cast embed with `?ref=…`), the query params on the URL the user opened are merged onto the declared `action.url` so the app still receives them. Params declared in `action.url` win on conflict. Previously these params were dropped whenever `action.url` was set.
+
 ## December 19, 2024
 
 - Added experimental [`signManifest`](/docs/sdk/actions/sign-manifest) action for domain manifest verification:

--- a/site/pages/docs/specification.mdx
+++ b/site/pages/docs/specification.mdx
@@ -53,7 +53,7 @@ A Mini App URL must have a MiniAppEmbed in a serialized form in the `fc:miniapp`
 | Property              | Type   | Required | Description                              | Constraints                                  |
 |-----------------------|--------|----------|------------------------------------------|----------------------------------------------|
 | type                  | string | Yes      | The type of action.                      | One of: `launch_frame`, `view_token`         |
-| url                   | string | No       | App URL to open. If not provided, defaults to full URL used to fetch the document. | Max length 1024 characters.                   |
+| url                   | string | No       | App URL to open. If not provided, defaults to full URL used to fetch the document. When provided, query params from the URL used to fetch the document are merged onto this URL (params declared here win on conflict). | Max length 1024 characters.                   |
 | name                  | string | Yes      |                                          | Name of the application                      |
 | splashImageUrl        | string | No       | URL of image to show on loading screen.  | Max length 32 characters. Must be 200x200px. |
 | splashBackgroundColor | string | No       | Hex color code to use on loading screen. | Hex color code.                              |


### PR DESCRIPTION
## Summary

Documents a client behavior change: when a Mini App declares its own `button.action.url`, the query params from the URL the user actually opened (e.g. a cast embed with `?ref=…`, `?tab=settings`) are now **merged onto** the declared launch URL instead of being dropped. App-declared params win on conflict.

This corresponds to the client-side change in merkle-team/monorepo (NEYN-12877), where the previous docs only described the *"if `action.url` not provided"* case and implied a declared `action.url` was used verbatim.

## Changes

- **`guides/sharing.mdx`** — `button.action.url` section: add that provided URLs still receive the opened URL's query params (declared params win).
- **`specification.mdx`** — Action Schema `url` row: same clarification in the formal spec table.
- **`sdk/changelog.mdx`** — new "What's New" entry describing the forwarding behavior.

## Notes

`specification.mdx` is the canonical Mini Apps spec — flagging in case this clarification should be socialized as a spec change rather than a docs-only edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)