### PR TITLE
fix(miniapp-sdk): validate HTTPS scheme in openUrl before dispatch

### DIFF
--- a/packages/miniapp-sdk/src/sdk.ts
+++ b/packages/miniapp-sdk/src/sdk.ts
@@ -108,7 +108,14 @@ export const sdk: MiniAppSDK = {
     },
     openUrl: (urlArg: string | { url: string }) => {
       const url = typeof urlArg === 'string' ? urlArg : urlArg.url
-      return miniAppHost.openUrl(url.trim())
+      const trimmedUrl = url.trim()
+      const parsed = new URL(trimmedUrl)
+      if (parsed.protocol !== 'https:') {
+        throw new Error(
+          `openUrl: only HTTPS URLs are allowed (got ${parsed.protocol})`,
+        )
+      }
+      return miniAppHost.openUrl(trimmedUrl)
     },
     addFrame: addMiniApp,
     addMiniApp,


### PR DESCRIPTION
## Summary

`sdk.actions.openUrl` currently forwards whatever string it receives to the host with no client-side scheme check. That means unsafe or unsupported URLs (`javascript:`, `data:`, `http:`, etc.) are only blocked if each host decides to reject them, and mini-app developers get little or no feedback when they pass a bad URL.

This change parses the URL with the built-in `URL` constructor and allows only the `https:` scheme before calling `miniAppHost.openUrl`. Anything else throws a clear error at call time.

## Changes

- In `packages/miniapp-sdk/src/sdk.ts`, trim the input URL, parse it, and reject non-HTTPS schemes with:

  `openUrl: only HTTPS URLs are allowed (got <protocol>)`

- Malformed URLs still fail via `new URL(...)`, same as a normal parse error.
- No new dependencies. Style matches the existing simple `throw new Error(...)` usage in this package.
- `@farcaster/miniapp-sdk` does not have a test suite, so no tests were added. `@farcaster/frame-sdk` re-exports this package, so it picks up the behavior automatically.

## Why HTTPS only

Matches the approach proposed in #590: give developers a consistent, immediate failure instead of relying on host-specific enforcement. Docs and examples already use HTTPS URLs.

## Test plan

- [ ] Call `sdk.actions.openUrl('https://farcaster.xyz')` and confirm it still dispatches to the host
- [ ] Call `sdk.actions.openUrl({ url: 'https://example.com' })` and confirm object form still works
- [ ] Call with `http://example.com` and confirm it throws the HTTPS-only error
- [ ] Call with `javascript:alert(1)` and confirm it throws
- [ ] Call with `data:text/html,hi` and confirm it throws
- [ ] Call with an invalid string (e.g. `not a url`) and confirm `new URL` rejects it

Fixes #590